### PR TITLE
feat(node): improve peer lifecycle and inference logging

### DIFF
--- a/pkg/node/inference.go
+++ b/pkg/node/inference.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -396,12 +397,93 @@ func (r *Runtime) InferRemoteStream(ctx context.Context, target peer.ID, req *ap
 }
 
 func logInferenceEvent(fields map[string]any) {
-	raw, err := json.Marshal(sanitizeInferenceLogFields(fields))
+	raw, err := marshalOrderedLogFields(orderInferenceLogFields(sanitizeInferenceLogFields(fields)))
 	if err != nil {
 		log.Printf("inference log marshal warning: %v", err)
 		return
 	}
 	log.Print(string(raw))
+}
+
+func orderInferenceLogFields(fields map[string]any) [][2]any {
+	if len(fields) == 0 {
+		return nil
+	}
+	priority := []string{
+		"event",
+		"request_id",
+		"model",
+		"remote_peer",
+		"stream",
+		"ok",
+		"latency_ms",
+		"ttft_ms",
+		"tokens_used",
+		"error",
+	}
+	out := make([][2]any, 0, len(fields))
+	used := make(map[string]struct{}, len(fields))
+	for _, key := range priority {
+		v, ok := fields[key]
+		if !ok || shouldOmitInferenceLogField(key, v) {
+			continue
+		}
+		out = append(out, [2]any{key, v})
+		used[key] = struct{}{}
+	}
+	extras := make([]string, 0, len(fields))
+	for key := range fields {
+		if _, ok := used[key]; ok {
+			continue
+		}
+		if shouldOmitInferenceLogField(key, fields[key]) {
+			continue
+		}
+		extras = append(extras, key)
+	}
+	sort.Strings(extras)
+	for _, key := range extras {
+		out = append(out, [2]any{key, fields[key]})
+	}
+	return out
+}
+
+func marshalOrderedLogFields(fields [][2]any) ([]byte, error) {
+	if len(fields) == 0 {
+		return []byte("{}"), nil
+	}
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, kv := range fields {
+		key, ok := kv[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("log field key must be string")
+		}
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		keyRaw, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		valRaw, err := json.Marshal(kv[1])
+		if err != nil {
+			return nil, err
+		}
+		b.Write(keyRaw)
+		b.WriteByte(':')
+		b.Write(valRaw)
+	}
+	b.WriteByte('}')
+	return []byte(b.String()), nil
+}
+
+func shouldOmitInferenceLogField(key string, v any) bool {
+	if key == "error" {
+		s, ok := v.(string)
+		return ok && strings.TrimSpace(s) == ""
+	}
+	return false
 }
 
 func sanitizeInferenceLogFields(fields map[string]any) map[string]any {

--- a/pkg/node/inference.go
+++ b/pkg/node/inference.go
@@ -397,12 +397,11 @@ func (r *Runtime) InferRemoteStream(ctx context.Context, target peer.ID, req *ap
 }
 
 func logInferenceEvent(fields map[string]any) {
-	raw, err := marshalOrderedLogFields(orderInferenceLogFields(sanitizeInferenceLogFields(fields)))
-	if err != nil {
-		log.Printf("inference log marshal warning: %v", err)
+	line := formatOrderedInferenceLogLine(orderInferenceLogFields(sanitizeInferenceLogFields(fields)))
+	if strings.TrimSpace(line) == "" {
 		return
 	}
-	log.Print(string(raw))
+	log.Print(line)
 }
 
 func orderInferenceLogFields(fields map[string]any) [][2]any {
@@ -448,34 +447,50 @@ func orderInferenceLogFields(fields map[string]any) [][2]any {
 	return out
 }
 
-func marshalOrderedLogFields(fields [][2]any) ([]byte, error) {
+func formatOrderedInferenceLogLine(fields [][2]any) string {
 	if len(fields) == 0 {
-		return []byte("{}"), nil
+		return ""
 	}
+	eventName := "inference_event"
+	start := 0
+	if k, ok := fields[0][0].(string); ok && k == "event" {
+		if v, ok := fields[0][1].(string); ok && strings.TrimSpace(v) != "" {
+			eventName = v
+		}
+		start = 1
+	}
+
 	var b strings.Builder
-	b.WriteByte('{')
-	for i, kv := range fields {
-		key, ok := kv[0].(string)
-		if !ok {
-			return nil, fmt.Errorf("log field key must be string")
+	b.WriteString(eventName)
+	for i := start; i < len(fields); i++ {
+		key, ok := fields[i][0].(string)
+		if !ok || key == "event" {
+			continue
 		}
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		keyRaw, err := json.Marshal(key)
-		if err != nil {
-			return nil, err
-		}
-		valRaw, err := json.Marshal(kv[1])
-		if err != nil {
-			return nil, err
-		}
-		b.Write(keyRaw)
-		b.WriteByte(':')
-		b.Write(valRaw)
+		b.WriteByte(' ')
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(formatInferenceLogValue(fields[i][1]))
 	}
-	b.WriteByte('}')
-	return []byte(b.String()), nil
+	return b.String()
+}
+
+func formatInferenceLogValue(v any) string {
+	switch t := v.(type) {
+	case string:
+		if strings.ContainsAny(t, " \t\n\"") {
+			return strconv.Quote(t)
+		}
+		return t
+	case []string:
+		return "[" + strings.Join(t, ",") + "]"
+	default:
+		raw, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Sprintf("%v", t)
+		}
+		return string(raw)
+	}
 }
 
 func shouldOmitInferenceLogField(key string, v any) bool {

--- a/pkg/node/logging_privacy_test.go
+++ b/pkg/node/logging_privacy_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestLogInferenceEventRedactsPromptFields(t *testing.T) {
-	t.Parallel()
 	const promptSecret = "NODE_SECRET_PROMPT_456"
 
 	var logs bytes.Buffer
@@ -28,5 +27,41 @@ func TestLogInferenceEventRedactsPromptFields(t *testing.T) {
 	out := logs.String()
 	if strings.Contains(out, promptSecret) {
 		t.Fatalf("prompt text leaked in node logs: %s", out)
+	}
+}
+
+func TestLogInferenceEventOrdersFieldsAndOmitsEmptyError(t *testing.T) {
+	var logs bytes.Buffer
+	prevWriter := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(prevWriter)
+
+	logInferenceEvent(map[string]any{
+		"remote_peer": "12D3KooX",
+		"latency_ms":  1234,
+		"tokens_used": 42,
+		"event":       "inference_server_complete",
+		"request_id":  "gw-1",
+		"model":       "qwen2.5-coder:7b",
+		"stream":      true,
+		"ok":          true,
+		"error":       "",
+		"ttft_ms":     321,
+	})
+
+	out := logs.String()
+	if strings.Contains(out, `"error":""`) {
+		t.Fatalf("expected empty error field to be omitted, got: %s", out)
+	}
+
+	eventIdx := strings.Index(out, `"event":"inference_server_complete"`)
+	reqIdx := strings.Index(out, `"request_id":"gw-1"`)
+	modelIdx := strings.Index(out, `"model":"qwen2.5-coder:7b"`)
+	peerIdx := strings.Index(out, `"remote_peer":"12D3KooX"`)
+	if eventIdx < 0 || reqIdx < 0 || modelIdx < 0 || peerIdx < 0 {
+		t.Fatalf("expected ordered keys in log output, got: %s", out)
+	}
+	if !(eventIdx < reqIdx && reqIdx < modelIdx && modelIdx < peerIdx) {
+		t.Fatalf("unexpected key order, got: %s", out)
 	}
 }

--- a/pkg/node/logging_privacy_test.go
+++ b/pkg/node/logging_privacy_test.go
@@ -50,14 +50,14 @@ func TestLogInferenceEventOrdersFieldsAndOmitsEmptyError(t *testing.T) {
 	})
 
 	out := logs.String()
-	if strings.Contains(out, `"error":""`) {
+	if strings.Contains(out, " error=") {
 		t.Fatalf("expected empty error field to be omitted, got: %s", out)
 	}
 
-	eventIdx := strings.Index(out, `"event":"inference_server_complete"`)
-	reqIdx := strings.Index(out, `"request_id":"gw-1"`)
-	modelIdx := strings.Index(out, `"model":"qwen2.5-coder:7b"`)
-	peerIdx := strings.Index(out, `"remote_peer":"12D3KooX"`)
+	eventIdx := strings.Index(out, "inference_server_complete")
+	reqIdx := strings.Index(out, "request_id=gw-1")
+	modelIdx := strings.Index(out, "model=qwen2.5-coder:7b")
+	peerIdx := strings.Index(out, "remote_peer=12D3KooX")
 	if eventIdx < 0 || reqIdx < 0 || modelIdx < 0 || peerIdx < 0 {
 		t.Fatalf("expected ordered keys in log output, got: %s", out)
 	}

--- a/pkg/node/observe.go
+++ b/pkg/node/observe.go
@@ -97,8 +97,7 @@ func (r *Runtime) logNewPeerFromHealth(fromPeerID string, payload []byte) {
 
 	var health HealthUpdate
 	if err := json.Unmarshal(payload, &health); err != nil {
-		log.Printf("network peer established: peer_id=%s addrs=%v models=[] pricing=[] decode_error=%q",
-			fromPeerID,
+		log.Printf("network peer established: peer=%v models=[] pricing=[] decode_error=%q",
 			r.peerAddrStrings(fromPeerID),
 			err.Error(),
 		)
@@ -108,9 +107,7 @@ func (r *Runtime) logNewPeerFromHealth(fromPeerID string, payload []byte) {
 	models := append([]string(nil), health.Models...)
 	sort.Strings(models)
 	pricing := formatModelPricingForLog(health.ModelPricing)
-	log.Printf("network peer established: peer_id=%s heartbeat_node_id=%s addrs=%v models=%v pricing=%v",
-		fromPeerID,
-		health.NodeID,
+	log.Printf("network peer established: peer=%v models=%v pricing=%v",
 		r.peerAddrStrings(fromPeerID),
 		models,
 		pricing,
@@ -122,9 +119,15 @@ func (r *Runtime) peerAddrStrings(peerID string) []string {
 	if err != nil {
 		return nil
 	}
-	addrs := r.host.Peerstore().Addrs(id)
-	out := make([]string, 0, len(addrs))
-	for _, addr := range addrs {
+	p2pAddrs, err := peer.AddrInfoToP2pAddrs(&peer.AddrInfo{
+		ID:    id,
+		Addrs: r.host.Peerstore().Addrs(id),
+	})
+	if err != nil || len(p2pAddrs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(p2pAddrs))
+	for _, addr := range p2pAddrs {
 		out = append(out, addr.String())
 	}
 	sort.Strings(out)

--- a/pkg/node/observe.go
+++ b/pkg/node/observe.go
@@ -49,10 +49,12 @@ func StartObserving(ctx context.Context, cfg *config.Config, onHealth func([]byt
 		return nil, fmt.Errorf("subscribe health topic: %w", err)
 	}
 	go r.healthSubscribeLoop(ctx, sub, onHealth)
-	// Seed routing table quickly when using default DHT bootstraps (no reconnect loop).
-	go func() {
-		r.ConnectBootstrapsOnce(ctx)
-	}()
+	// Seed routing table quickly only when reconnect loop is disabled.
+	if !r.reconnect {
+		go func() {
+			r.ConnectBootstrapsOnce(ctx)
+		}()
+	}
 	return r, nil
 }
 

--- a/pkg/node/observe.go
+++ b/pkg/node/observe.go
@@ -2,10 +2,14 @@ package node
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/mrostamii/tooti/pkg/config"
 )
@@ -70,8 +74,81 @@ func (r *Runtime) healthSubscribeLoop(ctx context.Context, sub *pubsub.Subscript
 		if len(data) == 0 {
 			continue
 		}
+		r.logNewPeerFromHealth(msg.GetFrom().String(), data)
 		if err := onHealth(data); err != nil {
 			log.Printf("health subscribe: apply payload: %v", err)
 		}
 	}
+}
+
+func (r *Runtime) logNewPeerFromHealth(fromPeerID string, payload []byte) {
+	if strings.TrimSpace(fromPeerID) == "" {
+		return
+	}
+	r.peerLogMu.Lock()
+	if _, ok := r.peerLogged[fromPeerID]; ok {
+		r.peerLogMu.Unlock()
+		return
+	}
+	r.peerLogged[fromPeerID] = struct{}{}
+	r.peerLogMu.Unlock()
+
+	var health HealthUpdate
+	if err := json.Unmarshal(payload, &health); err != nil {
+		log.Printf("network peer established: peer_id=%s addrs=%v models=[] pricing=[] decode_error=%q",
+			fromPeerID,
+			r.peerAddrStrings(fromPeerID),
+			err.Error(),
+		)
+		return
+	}
+
+	models := append([]string(nil), health.Models...)
+	sort.Strings(models)
+	pricing := formatModelPricingForLog(health.ModelPricing)
+	log.Printf("network peer established: peer_id=%s heartbeat_node_id=%s addrs=%v models=%v pricing=%v",
+		fromPeerID,
+		health.NodeID,
+		r.peerAddrStrings(fromPeerID),
+		models,
+		pricing,
+	)
+}
+
+func (r *Runtime) peerAddrStrings(peerID string) []string {
+	id, err := peer.Decode(peerID)
+	if err != nil {
+		return nil
+	}
+	addrs := r.host.Peerstore().Addrs(id)
+	out := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		out = append(out, addr.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatModelPricingForLog(pricing map[string]ModelPricingHint) []string {
+	if len(pricing) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(pricing))
+	for model := range pricing {
+		keys = append(keys, model)
+	}
+	sort.Strings(keys)
+
+	out := make([]string, 0, len(keys))
+	for _, model := range keys {
+		p := pricing[model]
+		out = append(out, fmt.Sprintf("%s:price_per_1k_atomic=%d,min_amount_atomic=%d,max_amount_atomic=%d,default_output_tokens=%d",
+			model,
+			p.PricePer1KAtomic,
+			p.MinAmountAtomic,
+			p.MaxAmountAtomic,
+			p.DefaultOutputTokens,
+		))
+	}
+	return out
 }

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -58,6 +58,22 @@ type natConfig struct {
 	AutoRelayEnabled    bool
 }
 
+type peerLifecycleLogger struct{}
+
+func (peerLifecycleLogger) Listen(network.Network, ma.Multiaddr)      {}
+func (peerLifecycleLogger) ListenClose(network.Network, ma.Multiaddr) {}
+func (peerLifecycleLogger) OpenedStream(network.Network, network.Stream) {
+}
+func (peerLifecycleLogger) ClosedStream(network.Network, network.Stream) {
+}
+func (peerLifecycleLogger) Connected(_ network.Network, c network.Conn) {
+	log.Printf("peer connected: peer=%s remote_addr=%s", c.RemotePeer(), c.RemoteMultiaddr())
+}
+func (peerLifecycleLogger) Disconnected(n network.Network, c network.Conn) {
+	remaining := len(n.ConnsToPeer(c.RemotePeer()))
+	log.Printf("peer disconnected: peer=%s remote_addr=%s remaining_conns=%d", c.RemotePeer(), c.RemoteMultiaddr(), remaining)
+}
+
 func resolveNATConfig(cfg *config.Config, bootstrapCount int) natConfig {
 	traversal := !cfg.Network.DisableNATTraversal
 	return natConfig{
@@ -149,6 +165,7 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		pendingPayByKey:    make(map[string]pendingInferenceResult),
 		peerLogged:         make(map[string]struct{}),
 	}
+	h.Network().Notify(peerLifecycleLogger{})
 	log.Printf("network nat: traversal=%t auto_relay=%t relay_service=%t bootstrap_candidates=%d",
 		natCfg.TraversalEnabled, natCfg.AutoRelayEnabled, natCfg.RelayServiceEnabled, len(bootstraps))
 	return r, nil

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -43,6 +43,8 @@ type Runtime struct {
 	peerLogged         map[string]struct{}
 	peerConnMu         sync.Mutex
 	peerConnCount      map[peer.ID]int
+	peerLastGone       map[peer.ID]time.Time
+	peerDisconTmr      map[peer.ID]*time.Timer
 
 	inflightInference atomic.Int64
 	statsMu           sync.RWMutex
@@ -60,12 +62,13 @@ type natConfig struct {
 	AutoRelayEnabled    bool
 }
 
-func (r *Runtime) Listen(network.Network, ma.Multiaddr)      {}
-func (r *Runtime) ListenClose(network.Network, ma.Multiaddr) {}
-func (r *Runtime) OpenedStream(network.Network, network.Stream) {
-}
-func (r *Runtime) ClosedStream(network.Network, network.Stream) {
-}
+const peerLogDebounce = 10 * time.Second
+
+func (r *Runtime) Listen(network.Network, ma.Multiaddr)         {}
+func (r *Runtime) ListenClose(network.Network, ma.Multiaddr)    {}
+func (r *Runtime) OpenedStream(network.Network, network.Stream) {}
+func (r *Runtime) ClosedStream(network.Network, network.Stream) {}
+
 func (r *Runtime) Connected(_ network.Network, c network.Conn) {
 	r.peerConnMu.Lock()
 	defer r.peerConnMu.Unlock()
@@ -73,10 +76,21 @@ func (r *Runtime) Connected(_ network.Network, c network.Conn) {
 	id := c.RemotePeer()
 	prev := r.peerConnCount[id]
 	r.peerConnCount[id] = prev + 1
+
+	if t, ok := r.peerDisconTmr[id]; ok {
+		t.Stop()
+		delete(r.peerDisconTmr, id)
+	}
+
 	if prev == 0 {
-		log.Printf("peer connected: peer=%s remote_addr=%s", id, c.RemoteMultiaddr())
+		lastGone, wasGone := r.peerLastGone[id]
+		delete(r.peerLastGone, id)
+		if !wasGone || time.Since(lastGone) >= peerLogDebounce {
+			log.Printf("peer connected: peer=%s addr=%s", id, c.RemoteMultiaddr())
+		}
 	}
 }
+
 func (r *Runtime) Disconnected(_ network.Network, c network.Conn) {
 	r.peerConnMu.Lock()
 	defer r.peerConnMu.Unlock()
@@ -85,7 +99,17 @@ func (r *Runtime) Disconnected(_ network.Network, c network.Conn) {
 	prev := r.peerConnCount[id]
 	if prev <= 1 {
 		delete(r.peerConnCount, id)
-		log.Printf("peer disconnected: peer=%s remote_addr=%s", id, c.RemoteMultiaddr())
+		r.peerLastGone[id] = time.Now()
+		addr := c.RemoteMultiaddr().String()
+		r.peerDisconTmr[id] = time.AfterFunc(peerLogDebounce, func() {
+			r.peerConnMu.Lock()
+			defer r.peerConnMu.Unlock()
+			if r.peerConnCount[id] > 0 {
+				return
+			}
+			delete(r.peerDisconTmr, id)
+			log.Printf("peer disconnected: peer=%s addr=%s", id, addr)
+		})
 		return
 	}
 	r.peerConnCount[id] = prev - 1
@@ -182,6 +206,8 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		pendingPayByKey:    make(map[string]pendingInferenceResult),
 		peerLogged:         make(map[string]struct{}),
 		peerConnCount:      make(map[peer.ID]int),
+		peerLastGone:       make(map[peer.ID]time.Time),
+		peerDisconTmr:      make(map[peer.ID]*time.Timer),
 	}
 	h.Network().Notify(r)
 	log.Printf("network nat: traversal=%t auto_relay=%t relay_service=%t bootstrap_candidates=%d",

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -39,6 +39,8 @@ type Runtime struct {
 	paymentDebtByPayer map[string]int64
 	pendingPayMu       sync.Mutex
 	pendingPayByKey    map[string]pendingInferenceResult
+	peerLogMu          sync.Mutex
+	peerLogged         map[string]struct{}
 
 	inflightInference atomic.Int64
 	statsMu           sync.RWMutex
@@ -145,6 +147,7 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		startedAt:          time.Now(),
 		paymentDebtByPayer: make(map[string]int64),
 		pendingPayByKey:    make(map[string]pendingInferenceResult),
+		peerLogged:         make(map[string]struct{}),
 	}
 	log.Printf("network nat: traversal=%t auto_relay=%t relay_service=%t bootstrap_candidates=%d",
 		natCfg.TraversalEnabled, natCfg.AutoRelayEnabled, natCfg.RelayServiceEnabled, len(bootstraps))

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -45,6 +45,7 @@ type Runtime struct {
 	peerConnCount      map[peer.ID]int
 	peerLastGone       map[peer.ID]time.Time
 	peerDisconTmr      map[peer.ID]*time.Timer
+	bootstrapPeerIDs   map[peer.ID]struct{}
 
 	inflightInference atomic.Int64
 	statsMu           sync.RWMutex
@@ -85,7 +86,7 @@ func (r *Runtime) Connected(_ network.Network, c network.Conn) {
 	if prev == 0 {
 		lastGone, wasGone := r.peerLastGone[id]
 		delete(r.peerLastGone, id)
-		if !wasGone || time.Since(lastGone) >= peerLogDebounce {
+		if (!wasGone || time.Since(lastGone) >= peerLogDebounce) && r.shouldLogPeerLifecycle(id) {
 			log.Printf("peer connected: peer=%s addr=%s", id, c.RemoteMultiaddr())
 		}
 	}
@@ -108,11 +109,23 @@ func (r *Runtime) Disconnected(_ network.Network, c network.Conn) {
 				return
 			}
 			delete(r.peerDisconTmr, id)
-			log.Printf("peer disconnected: peer=%s addr=%s", id, addr)
+			if r.shouldLogPeerLifecycle(id) {
+				log.Printf("peer disconnected: peer=%s addr=%s", id, addr)
+			}
 		})
 		return
 	}
 	r.peerConnCount[id] = prev - 1
+}
+
+func (r *Runtime) shouldLogPeerLifecycle(id peer.ID) bool {
+	if _, ok := r.bootstrapPeerIDs[id]; ok {
+		return true
+	}
+	r.peerLogMu.Lock()
+	defer r.peerLogMu.Unlock()
+	_, ok := r.peerLogged[id.String()]
+	return ok
 }
 
 func resolveNATConfig(cfg *config.Config, bootstrapCount int) natConfig {
@@ -208,6 +221,12 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		peerConnCount:      make(map[peer.ID]int),
 		peerLastGone:       make(map[peer.ID]time.Time),
 		peerDisconTmr:      make(map[peer.ID]*time.Timer),
+		bootstrapPeerIDs:   make(map[peer.ID]struct{}),
+	}
+	for _, b := range bootstraps {
+		if b.ID != "" {
+			r.bootstrapPeerIDs[b.ID] = struct{}{}
+		}
 	}
 	h.Network().Notify(r)
 	log.Printf("network nat: traversal=%t auto_relay=%t relay_service=%t bootstrap_candidates=%d",

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -41,6 +41,8 @@ type Runtime struct {
 	pendingPayByKey    map[string]pendingInferenceResult
 	peerLogMu          sync.Mutex
 	peerLogged         map[string]struct{}
+	peerConnMu         sync.Mutex
+	peerConnCount      map[peer.ID]int
 
 	inflightInference atomic.Int64
 	statsMu           sync.RWMutex
@@ -58,20 +60,35 @@ type natConfig struct {
 	AutoRelayEnabled    bool
 }
 
-type peerLifecycleLogger struct{}
+func (r *Runtime) Listen(network.Network, ma.Multiaddr)      {}
+func (r *Runtime) ListenClose(network.Network, ma.Multiaddr) {}
+func (r *Runtime) OpenedStream(network.Network, network.Stream) {
+}
+func (r *Runtime) ClosedStream(network.Network, network.Stream) {
+}
+func (r *Runtime) Connected(_ network.Network, c network.Conn) {
+	r.peerConnMu.Lock()
+	defer r.peerConnMu.Unlock()
 
-func (peerLifecycleLogger) Listen(network.Network, ma.Multiaddr)      {}
-func (peerLifecycleLogger) ListenClose(network.Network, ma.Multiaddr) {}
-func (peerLifecycleLogger) OpenedStream(network.Network, network.Stream) {
+	id := c.RemotePeer()
+	prev := r.peerConnCount[id]
+	r.peerConnCount[id] = prev + 1
+	if prev == 0 {
+		log.Printf("peer connected: peer=%s remote_addr=%s", id, c.RemoteMultiaddr())
+	}
 }
-func (peerLifecycleLogger) ClosedStream(network.Network, network.Stream) {
-}
-func (peerLifecycleLogger) Connected(_ network.Network, c network.Conn) {
-	log.Printf("peer connected: peer=%s remote_addr=%s", c.RemotePeer(), c.RemoteMultiaddr())
-}
-func (peerLifecycleLogger) Disconnected(n network.Network, c network.Conn) {
-	remaining := len(n.ConnsToPeer(c.RemotePeer()))
-	log.Printf("peer disconnected: peer=%s remote_addr=%s remaining_conns=%d", c.RemotePeer(), c.RemoteMultiaddr(), remaining)
+func (r *Runtime) Disconnected(_ network.Network, c network.Conn) {
+	r.peerConnMu.Lock()
+	defer r.peerConnMu.Unlock()
+
+	id := c.RemotePeer()
+	prev := r.peerConnCount[id]
+	if prev <= 1 {
+		delete(r.peerConnCount, id)
+		log.Printf("peer disconnected: peer=%s remote_addr=%s", id, c.RemoteMultiaddr())
+		return
+	}
+	r.peerConnCount[id] = prev - 1
 }
 
 func resolveNATConfig(cfg *config.Config, bootstrapCount int) natConfig {
@@ -164,8 +181,9 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		paymentDebtByPayer: make(map[string]int64),
 		pendingPayByKey:    make(map[string]pendingInferenceResult),
 		peerLogged:         make(map[string]struct{}),
+		peerConnCount:      make(map[peer.ID]int),
 	}
-	h.Network().Notify(peerLifecycleLogger{})
+	h.Network().Notify(r)
 	log.Printf("network nat: traversal=%t auto_relay=%t relay_service=%t bootstrap_candidates=%d",
 		natCfg.TraversalEnabled, natCfg.AutoRelayEnabled, natCfg.RelayServiceEnabled, len(bootstraps))
 	return r, nil

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -87,7 +87,7 @@ func (r *Runtime) Connected(_ network.Network, c network.Conn) {
 		lastGone, wasGone := r.peerLastGone[id]
 		delete(r.peerLastGone, id)
 		if (!wasGone || time.Since(lastGone) >= peerLogDebounce) && r.shouldLogPeerLifecycle(id) {
-			log.Printf("peer connected: peer=%s addr=%s", id, c.RemoteMultiaddr())
+			log.Printf("peer connected: peer=%s", formatPeerEndpoint(id, c.RemoteMultiaddr()))
 		}
 	}
 }
@@ -110,7 +110,7 @@ func (r *Runtime) Disconnected(_ network.Network, c network.Conn) {
 			}
 			delete(r.peerDisconTmr, id)
 			if r.shouldLogPeerLifecycle(id) {
-				log.Printf("peer disconnected: peer=%s addr=%s", id, addr)
+				log.Printf("peer disconnected: peer=%s", formatPeerEndpoint(id, ma.StringCast(addr)))
 			}
 		})
 		return
@@ -347,12 +347,42 @@ func (r *Runtime) connectBootstraps(ctx context.Context, logErrors bool) {
 		cancel()
 		if err != nil {
 			if logErrors {
-				log.Printf("bootstrap reconnect warning: peer=%s err=%v", b.ID, err)
+				log.Printf("bootstrap reconnect warning: peer=%v err=%v", formatPeerAddrInfo(b), err)
 			}
 			continue
 		}
-		log.Printf("bootstrap connected: peer=%s", b.ID)
+		log.Printf("bootstrap connected: peer=%v", formatPeerAddrInfo(b))
 	}
+}
+
+func formatPeerEndpoint(id peer.ID, addr ma.Multiaddr) string {
+	if addr == nil {
+		return fmt.Sprintf("/p2p/%s", id)
+	}
+	p2pAddrs, err := peer.AddrInfoToP2pAddrs(&peer.AddrInfo{
+		ID:    id,
+		Addrs: []ma.Multiaddr{addr},
+	})
+	if err != nil || len(p2pAddrs) == 0 {
+		return fmt.Sprintf("%s/p2p/%s", strings.TrimSuffix(addr.String(), "/"), id)
+	}
+	return p2pAddrs[0].String()
+}
+
+func formatPeerAddrInfo(info peer.AddrInfo) []string {
+	p2pAddrs, err := peer.AddrInfoToP2pAddrs(&info)
+	if err != nil || len(p2pAddrs) == 0 {
+		out := make([]string, 0, len(info.Addrs))
+		for _, a := range info.Addrs {
+			out = append(out, formatPeerEndpoint(info.ID, a))
+		}
+		return out
+	}
+	out := make([]string, 0, len(p2pAddrs))
+	for _, a := range p2pAddrs {
+		out = append(out, a.String())
+	}
+	return out
 }
 
 func ParseBootstrapPeers(raw []string) ([]peer.AddrInfo, error) {


### PR DESCRIPTION
## Summary

This PR improves node observability by making peer and inference logs more actionable and consistent.

### What changed

- add peer connect/disconnect lifecycle logging with debounce to reduce log noise from brief reconnect flaps
- track peer connection state and only emit lifecycle logs for relevant peers (bootstrap and discovered peers)
- improve bootstrap connection logs to include full peer endpoint/address info
- log newly discovered peers from health updates with model/pricing context
- format inference logs as ordered key/value lines with a stable field order for easier scanning and parsing
- omit empty `error` values from inference logs to reduce clutter
- add/extend logging privacy and formatting tests in `pkg/node/logging_privacy_test.go`

## Why

Current logs make it hard to quickly understand:
- which peers are actually active vs transiently reconnecting
- what capabilities a discovered peer exposes
- inference event timelines when fields appear in inconsistent order

These changes make logs cleaner for operators and easier to consume in downstream tooling.

## Test plan

- [x] run node unit tests, including `pkg/node/logging_privacy_test.go`
- [x] verify prompt-sensitive fields are still redacted in logs
- [x] verify empty `error` field is omitted
- [x] verify inference log key ordering is stable
- [x] smoke-test peer connect/disconnect logging behavior during reconnects