### PR TITLE
feat(node): private Tooti DHT and DNS bootstrap peer resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ flowchart LR
 - **Registry + Router**: tracks live nodes and selects where each request should go
 - **Gateway**: exposes `/v1/models` and `/v1/chat/completions` for client apps
 
+## Network bootstrap
+
+For the private DHT, configure `network.bootstrap_peers` (e.g. `/dnsaddr/discover.tooti.network` to expand peer ids from TXT, or a full `/ip4/.../p2p/...`).
+
 ## Quick start
 
 ### 1) Build

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ flowchart LR
 
 ## Network bootstrap
 
-For the private DHT, configure `network.bootstrap_peers` (e.g. `/dnsaddr/discover.tooti.network` to expand peer ids from TXT, or a full `/ip4/.../p2p/...`).
+Configure `network.bootstrap_peers` (e.g. `/dnsaddr/discover.tooti.network` to expand peer ids from TXT, or a full `/ip4/.../p2p/...`).
 
 ## Quick start
 

--- a/cmd/spike-libp2p/main.go
+++ b/cmd/spike-libp2p/main.go
@@ -1,7 +1,8 @@
-// Spike-libp2p is a Phase 0.2 hands-on exercise: join the public IPFS Kademlia DHT,
-// advertise a fixed rendezvous CID, discover a peer via FindProviders, open a stream,
-// and exchange one line of text. Use it to measure discovery latency and to observe
-// whether connections are direct or relayed (NAT / hole-punching signal).
+// Spike-libp2p is a Phase 0.2 hands-on exercise: join a Kademlia DHT (public IPFS
+// by default; pass -private-dht for the Tooti /tooti namespace), advertise a fixed
+// rendezvous CID, discover a peer via FindProviders, open a stream, and exchange
+// one line of text. Use it to measure discovery latency and to observe whether
+// connections are direct or relayed (NAT / hole-punching signal).
 package main
 
 import (
@@ -108,8 +109,15 @@ func listenAddrStrings(tcpPort, quicPort int) []string {
 	}
 }
 
-func mergeBootstrap(extra []peer.AddrInfo) func() []peer.AddrInfo {
+const spikePrivateDHTPrefix = "/tooti"
+
+func mergeBootstrap(extra []peer.AddrInfo, private bool) func() []peer.AddrInfo {
 	return func() []peer.AddrInfo {
+		if private {
+			out := make([]peer.AddrInfo, len(extra))
+			copy(out, extra)
+			return out
+		}
 		base := dht.GetDefaultBootstrapPeerAddrInfos()
 		if len(extra) == 0 {
 			return base
@@ -152,7 +160,7 @@ func connSummary(h interface {
 	return strings.Join(parts, "; ")
 }
 
-func runListen(ctx context.Context, bootstraps []peer.AddrInfo, tcpPort, quicPort int) error {
+func runListen(ctx context.Context, bootstraps []peer.AddrInfo, tcpPort, quicPort int, privateDHT bool) error {
 	h, err := libp2p.New(
 		libp2p.ListenAddrStrings(listenAddrStrings(tcpPort, quicPort)...),
 		libp2p.EnableRelay(),
@@ -164,10 +172,14 @@ func runListen(ctx context.Context, bootstraps []peer.AddrInfo, tcpPort, quicPor
 	}
 	defer h.Close()
 
-	kdht, err := dht.New(ctx, h,
+	dhtOpts := []dht.Option{
 		dht.Mode(dht.ModeServer),
-		dht.BootstrapPeersFunc(mergeBootstrap(bootstraps)),
-	)
+		dht.BootstrapPeersFunc(mergeBootstrap(bootstraps, privateDHT)),
+	}
+	if privateDHT {
+		dhtOpts = append(dhtOpts, dht.ProtocolPrefix(protocol.ID(spikePrivateDHTPrefix)))
+	}
+	kdht, err := dht.New(ctx, h, dhtOpts...)
 	if err != nil {
 		return err
 	}
@@ -211,7 +223,7 @@ func runListen(ctx context.Context, bootstraps []peer.AddrInfo, tcpPort, quicPor
 	return ctx.Err()
 }
 
-func runDial(ctx context.Context, bootstraps []peer.AddrInfo, directPeer string, message string, tcpPort, quicPort int) error {
+func runDial(ctx context.Context, bootstraps []peer.AddrInfo, directPeer string, message string, tcpPort, quicPort int, privateDHT bool) error {
 	h, err := libp2p.New(
 		libp2p.ListenAddrStrings(listenAddrStrings(tcpPort, quicPort)...),
 		libp2p.EnableRelay(),
@@ -223,10 +235,14 @@ func runDial(ctx context.Context, bootstraps []peer.AddrInfo, directPeer string,
 	}
 	defer h.Close()
 
-	kdht, err := dht.New(ctx, h,
+	dhtOpts := []dht.Option{
 		dht.Mode(dht.ModeClient),
-		dht.BootstrapPeersFunc(mergeBootstrap(bootstraps)),
-	)
+		dht.BootstrapPeersFunc(mergeBootstrap(bootstraps, privateDHT)),
+	}
+	if privateDHT {
+		dhtOpts = append(dhtOpts, dht.ProtocolPrefix(protocol.ID(spikePrivateDHTPrefix)))
+	}
+	kdht, err := dht.New(ctx, h, dhtOpts...)
 	if err != nil {
 		return err
 	}
@@ -317,14 +333,15 @@ func runDial(ctx context.Context, bootstraps []peer.AddrInfo, directPeer string,
 
 func main() {
 	var (
-		listen     = flag.Bool("listen", false, "server: DHT provide + echo handler until interrupted")
-		bootstrap  multiaddrList
-		peerAddr   = flag.String("peer", "", "client: optional full /ip4/.../p2p/<id> (skips DHT discovery)")
-		msg        = flag.String("msg", "hello from tooti spike", "client: one-line payload")
-		tcpPort    = flag.Int("tcp-port", 0, "local TCP listen port (0 = random)")
-		quicPort   = flag.Int("quic-port", 0, "local QUIC UDP listen port (0 = random)")
+		listen      = flag.Bool("listen", false, "server: DHT provide + echo handler until interrupted")
+		privateDHT  = flag.Bool("private-dht", false, "use Tooti private DHT (/tooti); -bootstrap required (no public IPFS bootstraps)")
+		bootstrap   multiaddrList
+		peerAddr    = flag.String("peer", "", "client: optional full /ip4/.../p2p/<id> (skips DHT discovery)")
+		msg         = flag.String("msg", "hello from tooti spike", "client: one-line payload")
+		tcpPort     = flag.Int("tcp-port", 0, "local TCP listen port (0 = random)")
+		quicPort    = flag.Int("quic-port", 0, "local QUIC UDP listen port (0 = random)")
 	)
-	flag.Var(&bootstrap, "bootstrap", "extra bootstrap multiaddr (repeatable); merged before default IPFS bootstraps")
+	flag.Var(&bootstrap, "bootstrap", "bootstrap multiaddr (repeatable); with default public DHT, merged before IPFS defaults; with -private-dht, only these are used")
 	flag.Parse()
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -333,6 +350,9 @@ func main() {
 	binfos, err := parseBootstrapAddrInfos(bootstrap)
 	if err != nil {
 		log.Fatal(err)
+	}
+	if *privateDHT && len(binfos) == 0 {
+		log.Fatal("-private-dht requires at least one -bootstrap multiaddr")
 	}
 
 	if *listen && *peerAddr != "" {
@@ -346,12 +366,12 @@ func main() {
 	}
 
 	if *listen {
-		if err := runListen(ctx, binfos, *tcpPort, *quicPort); err != nil && !errors.Is(err, context.Canceled) {
+		if err := runListen(ctx, binfos, *tcpPort, *quicPort, *privateDHT); err != nil && !errors.Is(err, context.Canceled) {
 			log.Fatal(err)
 		}
 		return
 	}
-	if err := runDial(ctx, binfos, *peerAddr, *msg, *tcpPort, *quicPort); err != nil {
+	if err := runDial(ctx, binfos, *peerAddr, *msg, *tcpPort, *quicPort, *privateDHT); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.39.0
 	github.com/libp2p/go-libp2p-pubsub v0.15.0
 	github.com/multiformats/go-multiaddr v0.16.1
+	github.com/multiformats/go-multiaddr-dns v0.5.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/crypto v0.49.0
@@ -78,7 +79,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
-	github.com/multiformats/go-multiaddr-dns v0.5.0 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.10.0 // indirect

--- a/node.example.yaml
+++ b/node.example.yaml
@@ -18,7 +18,12 @@ listen:
   quic_port: 4001
 
 network:
-  bootstrap_peers: []
+  # Default is the private Tooti DHT (not the public IPFS swarm). List at least
+  # one reachable bootstrap, e.g. DNS from discover.tooti.network once wired.
+  public_dht: false
+  bootstrap_peers:
+    - "/ip4/51.195.145.102/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
+  # Set public_dht: true only for local experiments against the public IPFS DHT.
   # NAT traversal is enabled by default. Set true only if you need to disable
   # hole punching / UPnP / AutoNAT for a restricted environment.
   disable_nat_traversal: false

--- a/node.example.yaml
+++ b/node.example.yaml
@@ -19,10 +19,11 @@ listen:
 
 network:
   # Default is the private Tooti DHT (not the public IPFS swarm). List at least
-  # one reachable bootstrap, e.g. DNS from discover.tooti.network once wired.
+  # one bootstrap entry. Peer ids can come from DNS TXT (dnsaddr-only) or from
+  # the multiaddr; see docs/discover-bootstrap.md.
   public_dht: false
   bootstrap_peers:
-    - "/ip4/51.195.145.102/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
+    - "/dnsaddr/discover.tooti.network"
   # Set public_dht: true only for local experiments against the public IPFS DHT.
   # NAT traversal is enabled by default. Set true only if you need to disable
   # hole punching / UPnP / AutoNAT for a restricted environment.

--- a/node.example.yaml
+++ b/node.example.yaml
@@ -18,15 +18,12 @@ listen:
   quic_port: 4001
 
 network:
-  # Default is the private Tooti DHT (not the public IPFS swarm). List at least
-  # one bootstrap entry. Peer ids can come from DNS TXT (dnsaddr-only) or from
-  # the multiaddr; see docs/discover-bootstrap.md.
-  public_dht: false
+  # At least one bootstrap. Peer ids can come from DNS TXT (dnsaddr-only) or from
+  # each multiaddr (_dnsaddr.<host> TXT records with dnsaddr=/ip4/.../p2p/...).
   bootstrap_peers:
     - "/dnsaddr/discover.tooti.network"
-  # Set public_dht: true only for local experiments against the public IPFS DHT.
-  # NAT traversal is enabled by default. Set true only if you need to disable
-  # hole punching / UPnP / AutoNAT for a restricted environment.
+  # NAT traversal is enabled by default. Set disable_nat_traversal: true only if
+  # you need to disable hole punching / UPnP / AutoNAT for a restricted environment.
   disable_nat_traversal: false
   # Optional: allow this node to act as a relay service when publicly reachable.
   enable_relay_service: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 
 	Network struct {
 		BootstrapPeers      []string `yaml:"bootstrap_peers"`
+		PublicDHT           bool     `yaml:"public_dht"`
 		DisableNATTraversal bool     `yaml:"disable_nat_traversal"`
 		EnableRelayService  bool     `yaml:"enable_relay_service"`
 	} `yaml:"network"`
@@ -217,6 +218,9 @@ func (c *Config) Validate() error {
 	}
 	if err := validatePort("listen.quic_port", c.Listen.QUICPort); err != nil {
 		return err
+	}
+	if !c.Network.PublicDHT && len(c.Network.BootstrapPeers) == 0 {
+		return fmt.Errorf("network.bootstrap_peers is required for the private Tooti DHT (omit network.public_dht or set false); set network.public_dht: true only to join the public IPFS DHT for experiments")
 	}
 	if c.Backend.Type != "ollama" {
 		return fmt.Errorf("backend.type must be \"ollama\" for v0.1")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,7 +52,6 @@ type Config struct {
 
 	Network struct {
 		BootstrapPeers      []string `yaml:"bootstrap_peers"`
-		PublicDHT           bool     `yaml:"public_dht"`
 		DisableNATTraversal bool     `yaml:"disable_nat_traversal"`
 		EnableRelayService  bool     `yaml:"enable_relay_service"`
 	} `yaml:"network"`
@@ -219,8 +218,8 @@ func (c *Config) Validate() error {
 	if err := validatePort("listen.quic_port", c.Listen.QUICPort); err != nil {
 		return err
 	}
-	if !c.Network.PublicDHT && len(c.Network.BootstrapPeers) == 0 {
-		return fmt.Errorf("network.bootstrap_peers is required for the private Tooti DHT (omit network.public_dht or set false); set network.public_dht: true only to join the public IPFS DHT for experiments")
+	if len(c.Network.BootstrapPeers) == 0 {
+		return fmt.Errorf("network.bootstrap_peers is required (Tooti uses the private /tooti DHT only)")
 	}
 	if c.Backend.Type != "ollama" {
 		return fmt.Errorf("backend.type must be \"ollama\" for v0.1")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -72,6 +72,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
 backend:
   type: "unknown"
   base_url: "not a url"
@@ -124,10 +125,10 @@ models:
 	}
 }
 
-func TestLoadAllowsEmptyBootstrapPeers(t *testing.T) {
+func TestLoadRejectsPrivateDHTWithoutBootstraps(t *testing.T) {
 	t.Parallel()
 	d := t.TempDir()
-	p := filepath.Join(d, "empty-bootstrap.yaml")
+	p := filepath.Join(d, "private-no-bootstrap.yaml")
 	err := os.WriteFile(p, []byte(`node:
   name: "x"
 listen:
@@ -147,8 +148,40 @@ models:
 	}
 
 	_, err = Load(p)
+	if err == nil {
+		t.Fatal("expected error for private DHT without bootstrap_peers")
+	}
+	if !strings.Contains(err.Error(), "network.bootstrap_peers") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadAllowsEmptyBootstrapPeersWithPublicDHT(t *testing.T) {
+	t.Parallel()
+	d := t.TempDir()
+	p := filepath.Join(d, "empty-bootstrap.yaml")
+	err := os.WriteFile(p, []byte(`node:
+  name: "x"
+listen:
+  tcp_port: 4001
+  quic_port: 4001
+network:
+  bootstrap_peers: []
+  public_dht: true
+backend:
+  type: "ollama"
+  base_url: "http://127.0.0.1:11434"
+models:
+  advertised:
+    - "llama3.2:latest"
+`), 0o644)
 	if err != nil {
-		t.Fatalf("expected empty bootstrap peers to be allowed, got: %v", err)
+		t.Fatal(err)
+	}
+
+	_, err = Load(p)
+	if err != nil {
+		t.Fatalf("expected empty bootstrap peers with public_dht, got: %v", err)
 	}
 }
 
@@ -163,6 +196,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
   disable_nat_traversal: true
   enable_relay_service: true
 backend:
@@ -199,6 +233,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
 models:
   advertised:
     - "llama3.2:latest"
@@ -230,6 +265,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
 models:
   advertised: []
 `), 0o644)
@@ -257,6 +293,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
 backend:
   type: "ollama"
   base_url: "http://127.0.0.1:11434"
@@ -289,6 +326,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
 backend:
   type: "ollama"
   base_url: "http://127.0.0.1:11434"
@@ -328,6 +366,7 @@ listen:
   quic_port: 4001
 network:
   bootstrap_peers: []
+  public_dht: true
 backend:
   type: "ollama"
   base_url: "http://127.0.0.1:11434"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,8 +71,8 @@ listen:
   tcp_port: 0
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
 backend:
   type: "unknown"
   base_url: "not a url"
@@ -125,10 +125,10 @@ models:
 	}
 }
 
-func TestLoadRejectsPrivateDHTWithoutBootstraps(t *testing.T) {
+func TestLoadRejectsEmptyBootstrapPeers(t *testing.T) {
 	t.Parallel()
 	d := t.TempDir()
-	p := filepath.Join(d, "private-no-bootstrap.yaml")
+	p := filepath.Join(d, "no-bootstrap.yaml")
 	err := os.WriteFile(p, []byte(`node:
   name: "x"
 listen:
@@ -149,39 +149,10 @@ models:
 
 	_, err = Load(p)
 	if err == nil {
-		t.Fatal("expected error for private DHT without bootstrap_peers")
+		t.Fatal("expected error for empty bootstrap_peers")
 	}
 	if !strings.Contains(err.Error(), "network.bootstrap_peers") {
 		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestLoadAllowsEmptyBootstrapPeersWithPublicDHT(t *testing.T) {
-	t.Parallel()
-	d := t.TempDir()
-	p := filepath.Join(d, "empty-bootstrap.yaml")
-	err := os.WriteFile(p, []byte(`node:
-  name: "x"
-listen:
-  tcp_port: 4001
-  quic_port: 4001
-network:
-  bootstrap_peers: []
-  public_dht: true
-backend:
-  type: "ollama"
-  base_url: "http://127.0.0.1:11434"
-models:
-  advertised:
-    - "llama3.2:latest"
-`), 0o644)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = Load(p)
-	if err != nil {
-		t.Fatalf("expected empty bootstrap peers with public_dht, got: %v", err)
 	}
 }
 
@@ -195,8 +166,8 @@ listen:
   tcp_port: 4001
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
   disable_nat_traversal: true
   enable_relay_service: true
 backend:
@@ -232,8 +203,8 @@ listen:
   tcp_port: 4001
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
 models:
   advertised:
     - "llama3.2:latest"
@@ -264,8 +235,8 @@ listen:
   tcp_port: 4001
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
 models:
   advertised: []
 `), 0o644)
@@ -292,8 +263,8 @@ listen:
   tcp_port: 4001
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
 backend:
   type: "ollama"
   base_url: "http://127.0.0.1:11434"
@@ -325,8 +296,8 @@ listen:
   tcp_port: 4001
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
 backend:
   type: "ollama"
   base_url: "http://127.0.0.1:11434"
@@ -365,8 +336,8 @@ listen:
   tcp_port: 4001
   quic_port: 4001
 network:
-  bootstrap_peers: []
-  public_dht: true
+  bootstrap_peers:
+    - "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
 backend:
   type: "ollama"
   base_url: "http://127.0.0.1:11434"

--- a/pkg/node/bootstrap_peers.go
+++ b/pkg/node/bootstrap_peers.go
@@ -1,0 +1,114 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	madns "github.com/multiformats/go-multiaddr-dns"
+)
+
+// ParseBootstrapPeers turns config strings into AddrInfos. Each entry may be:
+//   - A full p2p multiaddr, e.g. /ip4/.../tcp/4001/p2p/12D3KooW...
+//   - A dnsaddr (or dns4/dns6/dns) multiaddr without /p2p/..., e.g. /dnsaddr/discover.tooti.network.
+//     Those are resolved with DNS (TXT for dnsaddr); every resolved line must end with /p2p/<peer-id>.
+//   - A dnsaddr plus /p2p/<id> is treated as a normal p2p multiaddr (resolved at dial time by libp2p).
+//
+// Multiple resolved addresses for the same peer id are merged into one AddrInfo.
+func ParseBootstrapPeers(ctx context.Context, raw []string) ([]peer.AddrInfo, error) {
+	return parseBootstrapPeers(ctx, raw, madns.Resolve)
+}
+
+func parseBootstrapPeers(ctx context.Context, raw []string, resolve func(context.Context, ma.Multiaddr) ([]ma.Multiaddr, error)) ([]peer.AddrInfo, error) {
+	byID := make(map[peer.ID]peer.AddrInfo)
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		maddr, err := ma.NewMultiaddr(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bootstrap multiaddr %q: %w", s, err)
+		}
+
+		_, errP2P := maddr.ValueForProtocol(ma.P_P2P)
+		if errP2P == nil {
+			info, err := peer.AddrInfoFromP2pAddr(maddr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid bootstrap peer addr %q: %w", s, err)
+			}
+			mergeBootstrapAddrInfo(byID, *info)
+			continue
+		}
+		if !errors.Is(errP2P, ma.ErrProtocolNotFound) {
+			return nil, fmt.Errorf("bootstrap %q: %w", s, errP2P)
+		}
+
+		if !madns.Matches(maddr) {
+			return nil, fmt.Errorf("bootstrap %q must include /p2p/<peer-id> or be a resolvable dnsaddr/dns4/dns6/dns multiaddr (without /p2p) to expand from DNS", s)
+		}
+
+		resolved, err := resolve(ctx, maddr)
+		if err != nil {
+			return nil, fmt.Errorf("resolve bootstrap %q: %w", s, err)
+		}
+		if len(resolved) == 0 {
+			return nil, fmt.Errorf("bootstrap %q resolved to zero addresses", s)
+		}
+		var any bool
+		for _, r := range resolved {
+			info, err := peer.AddrInfoFromP2pAddr(r)
+			if err != nil {
+				continue
+			}
+			mergeBootstrapAddrInfo(byID, *info)
+			any = true
+		}
+		if !any {
+			return nil, fmt.Errorf("bootstrap %q: DNS resolution returned no valid p2p multiaddrs", s)
+		}
+	}
+
+	out := make([]peer.AddrInfo, 0, len(byID))
+	for _, ai := range byID {
+		out = append(out, ai)
+	}
+	return out, nil
+}
+
+func mergeBootstrapAddrInfo(byID map[peer.ID]peer.AddrInfo, ai peer.AddrInfo) {
+	if ai.ID == "" {
+		return
+	}
+	if ex, ok := byID[ai.ID]; ok {
+		ex.Addrs = appendUniqueMultiaddrs(ex.Addrs, ai.Addrs)
+		byID[ai.ID] = ex
+		return
+	}
+	byID[ai.ID] = peer.AddrInfo{
+		ID:    ai.ID,
+		Addrs: append([]ma.Multiaddr(nil), ai.Addrs...),
+	}
+}
+
+func appendUniqueMultiaddrs(base, extra []ma.Multiaddr) []ma.Multiaddr {
+	for _, a := range extra {
+		if a == nil {
+			continue
+		}
+		dup := false
+		for _, b := range base {
+			if b != nil && b.Equal(a) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			base = append(base, a)
+		}
+	}
+	return base
+}

--- a/pkg/node/observe.go
+++ b/pkg/node/observe.go
@@ -27,11 +27,7 @@ func StartObserving(ctx context.Context, cfg *config.Config, onHealth func([]byt
 	}
 	r.logDialAddrs()
 
-	if r.reconnect {
-		go r.bootstrapReconnectLoop(ctx)
-	} else {
-		log.Printf("default DHT bootstrap mode: reconnect loop disabled")
-	}
+	go r.bootstrapReconnectLoop(ctx)
 
 	ps, err := pubsub.NewGossipSub(ctx, r.host)
 	if err != nil {
@@ -49,12 +45,6 @@ func StartObserving(ctx context.Context, cfg *config.Config, onHealth func([]byt
 		return nil, fmt.Errorf("subscribe health topic: %w", err)
 	}
 	go r.healthSubscribeLoop(ctx, sub, onHealth)
-	// Seed routing table quickly only when reconnect loop is disabled.
-	if !r.reconnect {
-		go func() {
-			r.ConnectBootstrapsOnce(ctx)
-		}()
-	}
 	return r, nil
 }
 

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -36,7 +36,6 @@ type Runtime struct {
 	host               host.Host
 	dht                *dht.IpfsDHT
 	bootstraps         []peer.AddrInfo
-	reconnect          bool
 	startedAt          time.Time
 	metricsSrv         *http.Server
 	inferencePaywall   *x402InferencePaywallConfig
@@ -143,30 +142,11 @@ func resolveNATConfig(cfg *config.Config, bootstrapCount int) natConfig {
 }
 
 func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
-	var bootstraps []peer.AddrInfo
-	var err error
-	var useCustomBootstraps bool
-
-	if cfg.Network.PublicDHT {
-		if len(cfg.Network.BootstrapPeers) > 0 {
-			bootstraps, err = ParseBootstrapPeers(ctx, cfg.Network.BootstrapPeers)
-			if err != nil {
-				return nil, err
-			}
-			useCustomBootstraps = true
-			log.Printf("network.public_dht=true: public IPFS DHT with %d custom bootstrap peer(s)", len(bootstraps))
-		} else {
-			bootstraps = dht.GetDefaultBootstrapPeerAddrInfos()
-			log.Printf("network.public_dht=true: using %d default public IPFS DHT bootstrap peer(s)", len(bootstraps))
-		}
-	} else {
-		bootstraps, err = ParseBootstrapPeers(ctx, cfg.Network.BootstrapPeers)
-		if err != nil {
-			return nil, err
-		}
-		useCustomBootstraps = true
-		log.Printf("private Tooti DHT (prefix %s): %d bootstrap peer(s)", TootiDHTProtocolPrefix, len(bootstraps))
+	bootstraps, err := ParseBootstrapPeers(ctx, cfg.Network.BootstrapPeers)
+	if err != nil {
+		return nil, err
 	}
+	log.Printf("Tooti DHT (prefix %s): %d bootstrap peer(s)", TootiDHTProtocolPrefix, len(bootstraps))
 
 	listenTCP := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.Listen.TCPPort)
 	listenQUIC := fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", cfg.Listen.QUICPort)
@@ -210,14 +190,11 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		return nil, fmt.Errorf("create libp2p host: %w", err)
 	}
 
-	dhtOpts := []dht.Option{
+	kdht, err := dht.New(ctx, h,
 		dht.Mode(dhtMode),
 		dht.BootstrapPeers(bootstraps...),
-	}
-	if !cfg.Network.PublicDHT {
-		dhtOpts = append(dhtOpts, dht.ProtocolPrefix(protocol.ID(TootiDHTProtocolPrefix)))
-	}
-	kdht, err := dht.New(ctx, h, dhtOpts...)
+		dht.ProtocolPrefix(protocol.ID(TootiDHTProtocolPrefix)),
+	)
 	if err != nil {
 		_ = h.Close()
 		return nil, fmt.Errorf("create dht: %w", err)
@@ -233,7 +210,6 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		host:               h,
 		dht:                kdht,
 		bootstraps:         bootstraps,
-		reconnect:          useCustomBootstraps,
 		startedAt:          time.Now(),
 		paymentDebtByPayer: make(map[string]int64),
 		pendingPayByKey:    make(map[string]pendingInferenceResult),
@@ -262,11 +238,7 @@ func Start(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 	r.inferencePaywall = buildInferencePaywallConfig(cfg)
 	r.logDialAddrs()
 
-	if r.reconnect {
-		go r.bootstrapReconnectLoop(ctx)
-	} else {
-		log.Printf("default DHT bootstrap mode: reconnect loop disabled")
-	}
+	go r.bootstrapReconnectLoop(ctx)
 	if cfg.Metrics.Enabled {
 		metricsSrv, err := startMetricsServer(ctx, cfg.Metrics.Listen)
 		if err != nil {

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	ping "github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"
 	ma "github.com/multiformats/go-multiaddr"
@@ -26,6 +27,10 @@ import (
 )
 
 const bootstrapReconnectEvery = 30 * time.Second
+
+// TootiDHTProtocolPrefix is the libp2p Kademlia namespace for the Tooti network
+// (DHT sub-protocols become /tooti/kad/1.0.0, etc., instead of /ipfs/...).
+const TootiDHTProtocolPrefix = "/tooti"
 
 type Runtime struct {
 	host               host.Host
@@ -138,18 +143,29 @@ func resolveNATConfig(cfg *config.Config, bootstrapCount int) natConfig {
 }
 
 func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
-	useCustomBootstraps := len(cfg.Network.BootstrapPeers) > 0
 	var bootstraps []peer.AddrInfo
 	var err error
-	if useCustomBootstraps {
+	var useCustomBootstraps bool
+
+	if cfg.Network.PublicDHT {
+		if len(cfg.Network.BootstrapPeers) > 0 {
+			bootstraps, err = ParseBootstrapPeers(cfg.Network.BootstrapPeers)
+			if err != nil {
+				return nil, err
+			}
+			useCustomBootstraps = true
+			log.Printf("network.public_dht=true: public IPFS DHT with %d custom bootstrap peer(s)", len(bootstraps))
+		} else {
+			bootstraps = dht.GetDefaultBootstrapPeerAddrInfos()
+			log.Printf("network.public_dht=true: using %d default public IPFS DHT bootstrap peer(s)", len(bootstraps))
+		}
+	} else {
 		bootstraps, err = ParseBootstrapPeers(cfg.Network.BootstrapPeers)
 		if err != nil {
 			return nil, err
 		}
-		log.Printf("using %d custom bootstrap peer(s) from config", len(bootstraps))
-	} else {
-		bootstraps = dht.GetDefaultBootstrapPeerAddrInfos()
-		log.Printf("network.bootstrap_peers is empty; using %d default DHT bootstrap peer(s)", len(bootstraps))
+		useCustomBootstraps = true
+		log.Printf("private Tooti DHT (prefix %s): %d bootstrap peer(s)", TootiDHTProtocolPrefix, len(bootstraps))
 	}
 
 	listenTCP := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.Listen.TCPPort)
@@ -194,10 +210,14 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 		return nil, fmt.Errorf("create libp2p host: %w", err)
 	}
 
-	kdht, err := dht.New(ctx, h,
+	dhtOpts := []dht.Option{
 		dht.Mode(dhtMode),
 		dht.BootstrapPeers(bootstraps...),
-	)
+	}
+	if !cfg.Network.PublicDHT {
+		dhtOpts = append(dhtOpts, dht.ProtocolPrefix(protocol.ID(TootiDHTProtocolPrefix)))
+	}
+	kdht, err := dht.New(ctx, h, dhtOpts...)
 	if err != nil {
 		_ = h.Close()
 		return nil, fmt.Errorf("create dht: %w", err)

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -149,7 +149,7 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 
 	if cfg.Network.PublicDHT {
 		if len(cfg.Network.BootstrapPeers) > 0 {
-			bootstraps, err = ParseBootstrapPeers(cfg.Network.BootstrapPeers)
+			bootstraps, err = ParseBootstrapPeers(ctx, cfg.Network.BootstrapPeers)
 			if err != nil {
 				return nil, err
 			}
@@ -160,7 +160,7 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 			log.Printf("network.public_dht=true: using %d default public IPFS DHT bootstrap peer(s)", len(bootstraps))
 		}
 	} else {
-		bootstraps, err = ParseBootstrapPeers(cfg.Network.BootstrapPeers)
+		bootstraps, err = ParseBootstrapPeers(ctx, cfg.Network.BootstrapPeers)
 		if err != nil {
 			return nil, err
 		}
@@ -403,22 +403,6 @@ func formatPeerAddrInfo(info peer.AddrInfo) []string {
 		out = append(out, a.String())
 	}
 	return out
-}
-
-func ParseBootstrapPeers(raw []string) ([]peer.AddrInfo, error) {
-	out := make([]peer.AddrInfo, 0, len(raw))
-	for _, s := range raw {
-		maddr, err := ma.NewMultiaddr(s)
-		if err != nil {
-			return nil, fmt.Errorf("invalid bootstrap multiaddr %q: %w", s, err)
-		}
-		info, err := peer.AddrInfoFromP2pAddr(maddr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid bootstrap peer addr %q: %w", s, err)
-		}
-		out = append(out, *info)
-	}
-	return out, nil
 }
 
 func (r *Runtime) ConnectBootstrapsOnce(ctx context.Context) {

--- a/pkg/node/runtime_test.go
+++ b/pkg/node/runtime_test.go
@@ -1,15 +1,18 @@
 package node
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mrostamii/tooti/pkg/config"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 func TestParseBootstrapPeers(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	input := []string{"/ip4/51.195.145.102/tcp/4001/p2p/12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"}
-	peers, err := ParseBootstrapPeers(input)
+	peers, err := ParseBootstrapPeers(ctx, input)
 	if err != nil {
 		t.Fatalf("ParseBootstrapPeers() error = %v", err)
 	}
@@ -23,9 +26,62 @@ func TestParseBootstrapPeers(t *testing.T) {
 
 func TestParseBootstrapPeersInvalid(t *testing.T) {
 	t.Parallel()
-	_, err := ParseBootstrapPeers([]string{"not-a-multiaddr"})
+	_, err := ParseBootstrapPeers(context.Background(), []string{"not-a-multiaddr"})
 	if err == nil {
 		t.Fatal("expected error for invalid multiaddr")
+	}
+}
+
+func TestParseBootstrapPeersMergesSamePeerID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	id := "12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
+	raw := []string{
+		"/ip4/10.0.0.1/tcp/4001/p2p/" + id,
+		"/ip4/10.0.0.2/udp/4001/quic-v1/p2p/" + id,
+	}
+	peers, err := ParseBootstrapPeers(ctx, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 merged bootstrap, got %d", len(peers))
+	}
+	if len(peers[0].Addrs) != 2 {
+		t.Fatalf("expected 2 addrs for same peer, got %d", len(peers[0].Addrs))
+	}
+}
+
+func TestParseBootstrapPeersDNSAddrMockResolve(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	idA := "12D3KooWQXVG5RfM8P6Y1k9ihR1RUmfDfM2hPsoYwhhYp2Gy1AHJ"
+	idB := "12D3KooWRpDfHqHBJHHpDcTTb2Dmz4UoYHHXiApihxDwN13KqTw4"
+	mock := func(_ context.Context, _ ma.Multiaddr) ([]ma.Multiaddr, error) {
+		m1, err := ma.NewMultiaddr("/ip4/10.1.0.1/tcp/4001/p2p/" + idA)
+		if err != nil {
+			t.Fatal(err)
+		}
+		m2, err := ma.NewMultiaddr("/ip4/10.1.0.2/tcp/4001/p2p/" + idB)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return []ma.Multiaddr{m1, m2}, nil
+	}
+	peers, err := parseBootstrapPeers(ctx, []string{"/dnsaddr/tooti.test.invalid"}, mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 bootstraps from dnsaddr expand, got %d", len(peers))
+	}
+}
+
+func TestParseBootstrapPeersRejectsIPWithoutP2P(t *testing.T) {
+	t.Parallel()
+	_, err := ParseBootstrapPeers(context.Background(), []string{"/ip4/10.0.0.1/tcp/4001"})
+	if err == nil {
+		t.Fatal("expected error without /p2p")
 	}
 }
 


### PR DESCRIPTION
## Summary

The node now uses a **private Kademlia namespace** (`/tooti`, i.e. DHT sub-protocols under that prefix) instead of the public IPFS DHT. **At least one** `network.bootstrap_peers` entry is **required**; empty lists are rejected at config validation.

Bootstrap strings can be full `/…/p2p/<id>` multiaddrs or **dnsaddr-only** entries (e.g. `/dnsaddr/discover.tooti.network`) that are expanded via DNS into valid p2p multiaddrs, with **per-peer address merging** when the same peer id appears multiple times.

## What changed

- **DHT**: `dht.ProtocolPrefix("/tooti")` so routing/discovery is isolated to the Tooti network.
- **Bootstraps**: removed default `dht.GetDefaultBootstrapPeerAddrInfos()` path; always parse configured peers (with context for DNS resolution).
- **`ParseBootstrapPeers`**: moved to `pkg/node/bootstrap_peers.go`, accepts `context.Context`, supports dnsaddr resolution and merging addrs by peer id.
- **Observe / Start**: always run the bootstrap reconnect loop (no “default DHT / no custom bootstraps” branch).
- **Config**: `Validate()` requires non-empty `network.bootstrap_peers`.
- **Docs / example**: README “Network bootstrap” note; `node.example.yaml` shows `discover.tooti.network`.
- **Spike** (`cmd/spike-libp2p`): `-private-dht` uses `/tooti` and **only** `-bootstrap` peers (no IPFS defaults); public mode unchanged aside from flag docs.
- **Deps**: direct `github.com/multiformats/go-multiaddr-dns` for dnsaddr resolution.
- **Tests**: config rejects empty bootstraps; expanded `ParseBootstrapPeers` tests (merge, mock DNS, reject bare IP without `/p2p`).

## BREAKING CHANGE

- **`network.bootstrap_peers` must be set** (non-empty). Config load/validate fails otherwise.
- Nodes **no longer** fall back to **public IPFS DHT** bootstraps when `bootstrap_peers` was empty.

Operators must add at least one bootstrap (dnsaddr or full p2p multiaddr) before upgrading.

## Test plan

- [x] `go test ./...`
- [x] Start node with example config (dnsaddr + resolved TXT) and confirm DHT/bootstrap behavior
- [x] Confirm empty `bootstrap_peers` fails fast with a clear error