### PR TITLE
feat: prepaid-only inference, gateway peer allowlists, and prepaid chat CLI

### DIFF
--- a/cmd/tooti/main.go
+++ b/cmd/tooti/main.go
@@ -36,7 +36,7 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("tooti")
 		fmt.Println("usage: tooti config-check -file ./node.yaml")
-		fmt.Println("usage: tooti pay chat -url http://127.0.0.1:8080/v1/chat/completions -model qwen2.5:3b -message \"say hi\"")
+		fmt.Println("usage: tooti pay chat -url http://127.0.0.1:8080/v1/chat/completions [-api-key <prepaid>] -model qwen2.5:3b -message \"say hi\"")
 		fmt.Println("usage: tooti pay topup -gateway http://127.0.0.1:8080 -amount-usdc 5")
 		return
 	}
@@ -761,7 +761,7 @@ func runNetworkModels(args []string) {
 
 func runPay(args []string) {
 	if len(args) == 0 {
-		fmt.Println("usage: tooti pay chat -url http://127.0.0.1:8080/v1/chat/completions -model qwen2.5:3b -message \"say hi\"")
+		fmt.Println("usage: tooti pay chat -url http://127.0.0.1:8080/v1/chat/completions [-api-key <prepaid>] -model qwen2.5:3b -message \"say hi\"")
 		fmt.Println("usage: tooti pay topup -gateway http://127.0.0.1:8080 -amount-usdc 5")
 		fmt.Println("usage: tooti pay balance -gateway http://127.0.0.1:8080")
 		fmt.Println("usage: tooti pay rotate-key -gateway http://127.0.0.1:8080")
@@ -789,6 +789,7 @@ func runPay(args []string) {
 func runPayChat(args []string) {
 	fs := flag.NewFlagSet("pay chat", flag.ExitOnError)
 	url := fs.String("url", "http://127.0.0.1:8080/v1/chat/completions", "chat completions endpoint URL")
+	apiKeyFlag := fs.String("api-key", "", "prepaid API key (Bearer); defaults to ~/.tooti/pay-state.json profile for -url host")
 	model := fs.String("model", "qwen2.5:3b", "model name")
 	message := fs.String("message", "say hi", "user message content")
 	stream := fs.Bool("stream", true, "request streaming response")
@@ -796,13 +797,7 @@ func runPayChat(args []string) {
 	privateKey := fs.String("private-key", "", "optional private key override")
 	_ = fs.Parse(args)
 
-	client, err := x402client.NewFromEnv()
-	if err != nil {
-		log.Fatalf("wallet error: %v", err)
-	}
-	if strings.TrimSpace(*privateKey) != "" {
-		client.PrivateKey = strings.TrimSpace(*privateKey)
-	}
+	apiKey := prepaidAPIKeyForChatURL(*url, *apiKeyFlag)
 
 	body := map[string]any{
 		"model":  *model,
@@ -824,10 +819,28 @@ func runPayChat(args []string) {
 		log.Fatalf("request create error: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 
-	resp, err := client.DoWithPayment(req)
-	if err != nil {
-		log.Fatalf("request failed: %v", err)
+	var resp *http.Response
+	if apiKey != "" {
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			log.Fatalf("request failed: %v", err)
+		}
+	} else {
+		client, werr := x402client.NewFromEnv()
+		if werr != nil {
+			log.Fatalf("wallet error: %v (set EVM_PRIVATE_KEY for x402 chat, or use -api-key / pay topup for prepaid)", werr)
+		}
+		if strings.TrimSpace(*privateKey) != "" {
+			client.PrivateKey = strings.TrimSpace(*privateKey)
+		}
+		resp, err = client.DoWithPayment(req)
+		if err != nil {
+			log.Fatalf("request failed: %v", err)
+		}
 	}
 	defer resp.Body.Close()
 

--- a/cmd/tooti/main.go
+++ b/cmd/tooti/main.go
@@ -203,12 +203,12 @@ func runGatewayStart(args []string) {
 	listen := fs.String("listen", "", "gateway listen address override")
 	ollamaBase := fs.String("ollama", "", "ollama base URL override (optional)")
 	localBackend := fs.Bool("local-backend", false, "enable local Ollama fallback in gateway (default false: remote-only routing)")
-	x402Mode := fs.String("x402-mode", "off", "x402 mode: off|managed (managed = gateway-owned paywall, off = decentralized routing only)")
+	x402Mode := fs.String("x402-mode", "off", "deprecated; chat x402 removed — use prepaid API keys and x402 top-up only")
 	x402Enable := fs.Bool("x402-enable", false, "enable x402 payment requirement for /v1/chat/completions")
 	x402Facilitator := fs.String("x402-facilitator", "", "x402 facilitator base URL (e.g. https://x402.org/facilitator)")
 	x402Network := fs.String("x402-network", "eip155:84532", "x402 network in CAIP-2 format")
 	x402Asset := fs.String("x402-asset", "0x036CbD53842c5426634e7929541eC2318f3dCF7e", "x402 payment asset address")
-	x402Amount := fs.String("x402-amount", "10000", "x402 payment amount in token atomic units")
+	_ = fs.String("x402-amount", "10000", "x402 payment amount in token atomic units")
 	x402PricePer1K := fs.Int64("x402-price-per-1k", 0, "dynamic pricing: token atomic units per 1K estimated tokens (0 disables dynamic pricing)")
 	x402MinAmount := fs.Int64("x402-min-amount", 1000, "dynamic pricing: minimum charge per request in token atomic units")
 	x402DefaultOutputTokens := fs.Int64("x402-default-output-tokens", 256, "dynamic pricing: fallback output token estimate when request.max_tokens is absent")
@@ -412,65 +412,13 @@ func runGatewayStart(args []string) {
 	if mode == "" {
 		mode = "off"
 	}
-	if *x402Enable && mode == "off" {
-		// Backward compatibility: old scripts used -x402-enable only.
-		mode = "managed"
-		log.Printf("warning: -x402-enable is deprecated; use -x402-mode=managed")
+	if *x402Enable || mode == "managed" {
+		log.Printf("warning: per-request chat x402 (-x402-enable / -x402-mode=managed) is removed; billing is prepaid API keys + x402 top-up only")
 	}
-	if mode != "off" && mode != "managed" {
-		log.Fatalf("invalid -x402-mode %q (expected off|managed)", *x402Mode)
+	if mode != "" && mode != "off" {
+		log.Printf("warning: ignoring -x402-mode=%q (chat paywall disabled)", *x402Mode)
 	}
-
-	if mode == "managed" {
-		if resolvedX402PayTo == "" {
-			log.Fatalf("x402 managed mode requires -x402-payto")
-		}
-		paywallCfg := &gateway.X402PaywallConfig{
-			FacilitatorURL: strings.TrimSpace(*x402Facilitator),
-			Requirement: x402spike.PaymentRequirements{
-				Scheme:            "exact",
-				Network:           strings.TrimSpace(*x402Network),
-				Amount:            strings.TrimSpace(*x402Amount),
-				Asset:             strings.TrimSpace(*x402Asset),
-				PayTo:             resolvedX402PayTo,
-				MaxTimeoutSeconds: 60,
-				Extra: map[string]any{
-					"name":    strings.TrimSpace(*x402TokenName),
-					"version": strings.TrimSpace(*x402TokenVersion),
-				},
-			},
-		}
-		if len(modelPricingCfg) > 0 {
-			paywallCfg.ModelPricing = make(map[string]gateway.X402TokenPricingConfig, len(modelPricingCfg))
-			for model, mp := range modelPricingCfg {
-				paywallCfg.ModelPricing[model] = gateway.X402TokenPricingConfig{
-					AtomicPer1KTokens:   mp.PricePer1KAtomic,
-					MinAmountAtomic:     mp.MinAmountAtomic,
-					MaxAmountAtomic:     mp.MaxAmountAtomic,
-					DefaultOutputTokens: mp.DefaultOutputTokens,
-				}
-			}
-		}
-		if *x402PricePer1K > 0 {
-			paywallCfg.TokenPricing = &gateway.X402TokenPricingConfig{
-				AtomicPer1KTokens:   *x402PricePer1K,
-				MinAmountAtomic:     *x402MinAmount,
-				DefaultOutputTokens: *x402DefaultOutputTokens,
-			}
-		}
-		proxy.SetX402ChatPaywall(paywallCfg)
-		log.Printf("x402 paywall enabled for /v1/chat/completions network=%s amount=%s asset=%s payto=%s facilitator=%s dynamic_price_per_1k=%d min_amount=%d default_output_tokens=%d",
-			strings.TrimSpace(*x402Network),
-			strings.TrimSpace(*x402Amount),
-			strings.TrimSpace(*x402Asset),
-			resolvedX402PayTo,
-			strings.TrimSpace(*x402Facilitator),
-			*x402PricePer1K,
-			*x402MinAmount,
-			*x402DefaultOutputTokens)
-	} else {
-		log.Printf("x402 gateway paywall mode=off (decentralized routing only)")
-	}
+	log.Printf("gateway chat billing: prepaid API keys on official gateways; x402 only on /v1/prepaid/topup when configured")
 	if *localBackend {
 		log.Printf("gateway local backend fallback enabled (mode=hybrid)")
 	} else {

--- a/cmd/tooti/pay_prepaid.go
+++ b/cmd/tooti/pay_prepaid.go
@@ -46,6 +46,24 @@ func parsePayAmountShortcut(raw string) (float64, bool) {
 	return v, true
 }
 
+// prepaidAPIKeyForChatURL returns explicitKey if set, otherwise the API key saved in pay-state
+// for the gateway host derived from chatURL (same profile key as pay topup/balance).
+func prepaidAPIKeyForChatURL(chatURL, explicitKey string) string {
+	if k := strings.TrimSpace(explicitKey); k != "" {
+		return k
+	}
+	u, err := url.Parse(strings.TrimSpace(chatURL))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	base := (&url.URL{Scheme: u.Scheme, Host: u.Host}).String()
+	state, err := loadPayState()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(state.Profiles[normalizeGatewayURL(base)].APIKey)
+}
+
 func runPayTopup(args []string) {
 	fs := flag.NewFlagSet("pay topup", flag.ExitOnError)
 	gatewayURL := fs.String("gateway", "http://127.0.0.1:8080", "official gateway base URL")

--- a/node.example.yaml
+++ b/node.example.yaml
@@ -1,6 +1,11 @@
 node:
   name: "ovh-lon-1"
   identity_key_file: "./data/node_identity.key" # persist peer ID across restarts
+  # Optional: when non-empty, only these libp2p peers (official gateways) may open
+  # inference streams. Empty = allow any peer (homelab). Users bill via gateway;
+  # configure each gateway's peer id from its logs (`node peer id`).
+  # allowed_gateway_peers:
+  #   - "12D3KooW..."
   x402:
     enabled: false
     facilitator_url: "https://x402.org/facilitator"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,10 @@ type Config struct {
 	Node struct {
 		Name            string `yaml:"name"`
 		IdentityKeyFile string `yaml:"identity_key_file"`
-		X402            struct {
+		// AllowedGatewayPeers lists libp2p peer IDs of official gateways that may open
+		// inference streams when non-empty. Empty allows any peer (local/homelab).
+		AllowedGatewayPeers []string `yaml:"allowed_gateway_peers"`
+		X402                struct {
 			Enabled             bool   `yaml:"enabled"`
 			FacilitatorURL      string `yaml:"facilitator_url"`
 			Network             string `yaml:"network"`
@@ -89,7 +92,7 @@ type Config struct {
 		ControlAPIToken string `yaml:"control_api_token"`
 		// AuthMode controls API key behavior for hosted gateways.
 		// Allowed: off | optional | required
-		AuthMode  string `yaml:"auth_mode"`
+		AuthMode string `yaml:"auth_mode"`
 		Telemetry struct {
 			Enabled          bool   `yaml:"enabled"`
 			Endpoint         string `yaml:"endpoint"`

--- a/pkg/gateway/openai_proxy.go
+++ b/pkg/gateway/openai_proxy.go
@@ -139,6 +139,13 @@ func (p *OpenAIProxy) SetAuthMode(mode string) {
 	p.authMode = mode
 }
 
+// isOfficialPrepaidOnly is true for hosted gateways with a control store (prepaid DB).
+func (p *OpenAIProxy) isOfficialPrepaidOnly() bool {
+	return p != nil &&
+		strings.EqualFold(strings.TrimSpace(p.gatewayMode), "official") &&
+		p.controlStore != nil
+}
+
 func (p *OpenAIProxy) SetPeerLatencyFunc(fn PeerLatencyFunc) {
 	p.peerLatency = fn
 }
@@ -313,11 +320,20 @@ func (p *OpenAIProxy) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
+	if p.isOfficialPrepaidOnly() {
+		if principal == nil || !strings.EqualFold(strings.TrimSpace(principal.ConsumerType), "prepaid") {
+			_ = writeJSON(w, http.StatusForbidden, openAIError(http.StatusForbidden, "official gateway requires a prepaid API key"))
+			return
+		}
+	}
 	prepaidSession, ok := p.beginPrepaidReservation(w, r, requestID, principal, &oreq)
 	if !ok {
 		return
 	}
-	if !p.enforceChatPayment(w, r, &oreq) {
+	// Official gateways bill prepaid only on chat; x402 is reserved for /v1/prepaid/topup.
+	// Community gateways may still enable managed chat x402 when configured.
+	needChatX402 := !p.isOfficialPrepaidOnly() && (prepaidSession == nil || !prepaidSession.Enabled)
+	if needChatX402 && !p.enforceChatPayment(w, r, &oreq) {
 		p.finalizePrepaidReservation(r.Context(), prepaidSession, &oreq, 0, false)
 		return
 	}
@@ -358,13 +374,17 @@ func (p *OpenAIProxy) handleChatCompletions(w http.ResponseWriter, r *http.Reque
 		nodes := rankedNodesForModel(p.reg, oreq.Model)
 		nodes = p.reorderNodesByPing(r.Context(), nodes)
 		if len(nodes) > 0 {
+			paymentSig := strings.TrimSpace(r.Header.Get("PAYMENT-SIGNATURE"))
+			if p.isOfficialPrepaidOnly() {
+				paymentSig = ""
+			}
 			remoteReq := &RemoteChatRequest{
 				RequestID:        requestID,
 				Model:            oreq.Model,
 				MaxTokens:        oreq.MaxTokens,
 				Messages:         make([]RemoteChatMessage, 0, len(oreq.Messages)),
 				Temperature:      oreq.Temperature,
-				PaymentSignature: strings.TrimSpace(r.Header.Get("PAYMENT-SIGNATURE")),
+				PaymentSignature: paymentSig,
 				ResourceURL:      requestURL(r),
 			}
 			for _, msg := range oreq.Messages {
@@ -497,12 +517,16 @@ func (p *OpenAIProxy) handleChatCompletionsStream(w http.ResponseWriter, r *http
 			}
 			selectedNode = node.NodeID
 			attemptStarted := time.Now()
-			rc, err := p.remoteStreamChat(reqCtx, node.NodeID, &RemoteChatRequest{
+			streamSig := strings.TrimSpace(r.Header.Get("PAYMENT-SIGNATURE"))
+			if p.isOfficialPrepaidOnly() {
+				streamSig = ""
+			}
+			streamRemote := &RemoteChatRequest{
 				RequestID:        requestID,
 				Model:            oreq.Model,
 				MaxTokens:        oreq.MaxTokens,
 				Temperature:      oreq.Temperature,
-				PaymentSignature: strings.TrimSpace(r.Header.Get("PAYMENT-SIGNATURE")),
+				PaymentSignature: streamSig,
 				ResourceURL:      requestURL(r),
 				Messages: func() []RemoteChatMessage {
 					out := make([]RemoteChatMessage, 0, len(oreq.Messages))
@@ -511,7 +535,8 @@ func (p *OpenAIProxy) handleChatCompletionsStream(w http.ResponseWriter, r *http
 					}
 					return out
 				}(),
-			})
+			}
+			rc, err := p.remoteStreamChat(reqCtx, node.NodeID, streamRemote)
 			if err != nil {
 				var payErr *RemotePaymentRequiredError
 				if errors.As(err, &payErr) {

--- a/pkg/gateway/openai_proxy_test.go
+++ b/pkg/gateway/openai_proxy_test.go
@@ -256,6 +256,109 @@ func TestHandleChatCompletionsPrepaidFinalizesReservation(t *testing.T) {
 	}
 }
 
+func TestHandleChatCompletionsPrepaidSkipsManagedX402Paywall(t *testing.T) {
+	t.Parallel()
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{
+			"model":"llama3.2:latest",
+			"message":{"role":"assistant","content":"hi"},
+			"prompt_eval_count":5,
+			"eval_count":3
+		}`))
+	}))
+	defer ollama.Close()
+
+	p := NewOpenAIProxy("127.0.0.1:0", ollama.URL, nil)
+	store := &mockControlStore{
+		lookupAPIKeyResult: &APIKeyPrincipal{
+			ConsumerID:   "consumer-prepaid",
+			ConsumerType: "prepaid",
+		},
+		reservePrepaidResult: PrepaidReserveResult{
+			Approved:     true,
+			ReservedUSDC: 0.01,
+			BalanceAfter: 1.0,
+		},
+	}
+	p.SetControlStore(store)
+	p.SetAuthMode("required")
+	p.SetX402ChatPaywall(&X402PaywallConfig{
+		Requirement: x402spike.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "eip155:84532",
+			Amount:            "10000",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			PayTo:             "0x0000000000000000000000000000000000000001",
+			MaxTimeoutSeconds: 60,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model":"llama3.2:latest",
+		"messages":[{"role":"user","content":"hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer toot_api_test")
+	// Deliberately no PAYMENT-SIGNATURE — managed paywall must not apply for prepaid.
+	rr := httptest.NewRecorder()
+	p.handleChatCompletions(rr, req)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status=%d want %d", rr.Result().StatusCode, http.StatusOK)
+	}
+	if !store.reservePrepaidCalled {
+		t.Fatal("expected reserve prepaid to be called")
+	}
+	if !store.finalizePrepaidCalled {
+		t.Fatal("expected finalize prepaid to be called")
+	}
+}
+
+func TestHandleChatCompletionsManagedX402RequiresPaymentWithoutPrepaidHold(t *testing.T) {
+	t.Parallel()
+	p := NewOpenAIProxy("127.0.0.1:0", "http://unused", nil)
+	store := &mockControlStore{
+		lookupAPIKeyResult: &APIKeyPrincipal{
+			ConsumerID:   "consumer-x402",
+			ConsumerType: "x402",
+		},
+	}
+	p.SetControlStore(store)
+	p.SetAuthMode("required")
+	p.SetX402ChatPaywall(&X402PaywallConfig{
+		Requirement: x402spike.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "eip155:84532",
+			Amount:            "10000",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			PayTo:             "0x0000000000000000000000000000000000000001",
+			MaxTimeoutSeconds: 60,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model":"llama3.2:latest",
+		"messages":[{"role":"user","content":"hello"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer toot_api_test")
+	rr := httptest.NewRecorder()
+	p.handleChatCompletions(rr, req)
+
+	if rr.Result().StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("status=%d want %d", rr.Result().StatusCode, http.StatusPaymentRequired)
+	}
+	if store.reservePrepaidCalled {
+		t.Fatal("did not expect prepaid reserve for x402 consumer")
+	}
+	if rr.Result().Header.Get("PAYMENT-REQUIRED") == "" {
+		t.Fatal("expected PAYMENT-REQUIRED header")
+	}
+}
+
 func TestHandleChatCompletionsOfficialRecordsUsageEvent(t *testing.T) {
 	t.Parallel()
 	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -271,7 +374,17 @@ func TestHandleChatCompletionsOfficialRecordsUsageEvent(t *testing.T) {
 	}))
 	defer ollama.Close()
 
-	store := &mockControlStore{}
+	store := &mockControlStore{
+		lookupAPIKeyResult: &APIKeyPrincipal{
+			ConsumerID:   "consumer-official",
+			ConsumerType: "prepaid",
+		},
+		reservePrepaidResult: PrepaidReserveResult{
+			Approved:     true,
+			ReservedUSDC: 1,
+			BalanceAfter: 10,
+		},
+	}
 	p := NewOpenAIProxy("127.0.0.1:0", ollama.URL, nil)
 	p.SetGatewayMode("official")
 	p.SetGatewayID("gw-test")
@@ -283,6 +396,7 @@ func TestHandleChatCompletionsOfficialRecordsUsageEvent(t *testing.T) {
 		"messages":[{"role":"user","content":"hello"}]
 	}`))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tooti_prepaid_key")
 	rr := httptest.NewRecorder()
 	p.handleChatCompletions(rr, req)
 
@@ -305,7 +419,7 @@ func TestHandleChatCompletionsOfficialRecordsUsageEvent(t *testing.T) {
 	if ev.Model != "llama3.2:latest" || ev.TokensIn != 4 || ev.TokensOut != 2 {
 		t.Fatalf("tokens/model: %+v", ev)
 	}
-	if ev.Status != "ok" || ev.PaymentMethod != "none" {
+	if ev.Status != "ok" || ev.PaymentMethod != "prepaid" {
 		t.Fatalf("status/payment: %+v", ev)
 	}
 }

--- a/pkg/node/inference.go
+++ b/pkg/node/inference.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/mrostamii/tooti/pkg/apiv1"
 	"github.com/mrostamii/tooti/pkg/backend/ollama"
-	"github.com/mrostamii/tooti/pkg/x402spike"
 )
 
 const InferenceProtocolID = protocol.ID("/tooti/v0.1/inference/1.0.0")
@@ -42,7 +41,6 @@ func (r *Runtime) registerInferenceHandler(backend inferenceBackend) {
 		reqID := ""
 		model := ""
 		tokensUsed := int64(0)
-		var paymentSession *inferencePaymentSession
 		success := false
 		failure := ""
 		defer func() {
@@ -69,31 +67,14 @@ func (r *Runtime) registerInferenceHandler(backend inferenceBackend) {
 		}
 		reqID = req.GetRequestId()
 		model = req.GetModel()
-		if sess, paymentErr, ok := r.enforceInferencePayment(&req); !ok {
-			failure = "payment required"
+		remoteID := s.Conn().RemotePeer()
+		if !r.isAllowedInferencePeer(remoteID) {
+			failure = "unauthorized inference peer"
 			_ = json.NewEncoder(s).Encode(&apiv1.InferenceResponse{
 				RequestId:    req.GetRequestId(),
 				Ok:           false,
-				ErrorMessage: paymentErr,
+				ErrorMessage: "unauthorized inference peer",
 			})
-			return
-		} else {
-			paymentSession = sess
-		}
-		if paymentSession != nil && paymentSession.PendingResult != nil {
-			success = true
-			tokensUsed = paymentSession.PendingResult.TokensUsed
-			resp := &apiv1.InferenceResponse{
-				RequestId:  req.GetRequestId(),
-				Content:    paymentSession.PendingResult.Content,
-				TokensUsed: paymentSession.PendingResult.TokensUsed,
-				LatencyMs:  paymentSession.PendingResult.LatencyMs,
-				Ok:         true,
-			}
-			if err := json.NewEncoder(s).Encode(resp); err != nil {
-				log.Printf("inference stream encode warning: %v", err)
-			}
-			r.deletePendingInferenceResult(paymentSession.PaymentKey)
 			return
 		}
 		started := time.Now()
@@ -112,38 +93,6 @@ func (r *Runtime) registerInferenceHandler(backend inferenceBackend) {
 		r.recordInferenceSample(total, total, resp.GetTokensUsed())
 		tokensUsed = resp.GetTokensUsed()
 		resp.LatencyMs = time.Since(started).Milliseconds()
-		if paymentSession != nil {
-			actualDue := r.computeActualDueAtomic(paymentSession, tokensUsed)
-			outstanding := paymentSession.PriorDebtAtomic + actualDue - paymentSession.PrepaidAtomic
-			if outstanding > 0 {
-				r.setPaymentDebt(paymentSession.Payer, outstanding)
-				r.setPendingInferenceResult(paymentSession.PaymentKey, pendingInferenceResult{
-					Content:    resp.GetContent(),
-					TokensUsed: tokensUsed,
-					LatencyMs:  resp.GetLatencyMs(),
-				})
-				finalReq := paymentSession.Requirement
-				finalReq.Amount = strconv.FormatInt(outstanding, 10)
-				pr := x402spike.PaymentRequired{
-					X402Version: 2,
-					Error:       "final payment required for exact settlement",
-					Resource: x402spike.ResourceInfo{
-						URL:         paymentSession.ResourceURL,
-						Description: "final settlement for completed inference",
-						MimeType:    "application/json",
-					},
-					Accepts: []x402spike.PaymentRequirements{finalReq},
-				}
-				failure = "payment required"
-				_ = json.NewEncoder(s).Encode(&apiv1.InferenceResponse{
-					RequestId:    req.GetRequestId(),
-					Ok:           false,
-					ErrorMessage: encodePaymentRequiredEnvelope("final payment required", pr, x402spike.SettlementResponse{}),
-				})
-				return
-			}
-		}
-		r.reconcileActualUsage(paymentSession, tokensUsed)
 		success = true
 		if err := json.NewEncoder(s).Encode(resp); err != nil {
 			log.Printf("inference stream encode warning: %v", err)
@@ -160,7 +109,6 @@ func (r *Runtime) registerInferenceStreamHandler(backend streamInferenceBackend)
 		reqID := ""
 		model := ""
 		tokensUsed := int64(0)
-		var paymentSession *inferencePaymentSession
 		success := false
 		failure := ""
 		var sampleTotal time.Duration
@@ -197,17 +145,16 @@ func (r *Runtime) registerInferenceStreamHandler(backend streamInferenceBackend)
 		}
 		reqID = req.GetRequestId()
 		model = req.GetModel()
-		if sess, paymentErr, ok := r.enforceInferencePayment(&req); !ok {
-			failure = "payment required"
+		remoteID := s.Conn().RemotePeer()
+		if !r.isAllowedInferencePeer(remoteID) {
+			failure = "unauthorized inference peer"
 			_ = json.NewEncoder(s).Encode(&apiv1.InferenceStreamChunk{
 				RequestId:    req.GetRequestId(),
 				Done:         true,
 				Ok:           false,
-				ErrorMessage: paymentErr,
+				ErrorMessage: "unauthorized inference peer",
 			})
 			return
-		} else {
-			paymentSession = sess
 		}
 		rc, err := inferStreamWithBackend(context.Background(), backend, &req)
 		if err != nil {
@@ -273,14 +220,10 @@ func (r *Runtime) registerInferenceStreamHandler(backend streamInferenceBackend)
 				Ok:         true,
 			}); err != nil {
 				failure = "encode response chunk: " + err.Error()
-				if paymentSession != nil {
-					r.markAbortedStreamDebt(paymentSession)
-				}
 				return
 			}
 			if chunk.Done {
 				tokensUsed = int64(chunk.PromptEvalCount + chunk.EvalCount)
-				r.reconcileActualUsage(paymentSession, tokensUsed)
 				sampleTotal = time.Since(streamStarted)
 				if sampleTTFT <= 0 {
 					sampleTTFT = sampleTotal

--- a/pkg/node/inference_allow_test.go
+++ b/pkg/node/inference_allow_test.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"crypto/rand"
+	"testing"
+
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func newTestPeerID(t *testing.T) peer.ID {
+	t.Helper()
+	_, pub, err := ic.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func TestIsAllowedInferencePeer_OpenAllowlist(t *testing.T) {
+	t.Parallel()
+	id := newTestPeerID(t)
+	r := &Runtime{}
+	if !r.isAllowedInferencePeer(id) {
+		t.Fatal("empty allowlist must allow any peer")
+	}
+}
+
+func TestIsAllowedInferencePeer_Whitelist(t *testing.T) {
+	t.Parallel()
+	good := newTestPeerID(t)
+	bad := newTestPeerID(t)
+	r := &Runtime{
+		allowedGatewayPeers: map[peer.ID]struct{}{
+			good: {},
+		},
+	}
+	if !r.isAllowedInferencePeer(good) {
+		t.Fatal("listed peer should be allowed")
+	}
+	if r.isAllowedInferencePeer(bad) {
+		t.Fatal("non-listed peer must be rejected")
+	}
+}

--- a/pkg/node/runtime.go
+++ b/pkg/node/runtime.go
@@ -33,23 +33,21 @@ const bootstrapReconnectEvery = 30 * time.Second
 const TootiDHTProtocolPrefix = "/tooti"
 
 type Runtime struct {
-	host               host.Host
-	dht                *dht.IpfsDHT
-	bootstraps         []peer.AddrInfo
-	startedAt          time.Time
-	metricsSrv         *http.Server
-	inferencePaywall   *x402InferencePaywallConfig
-	paymentDebtMu      sync.Mutex
-	paymentDebtByPayer map[string]int64
-	pendingPayMu       sync.Mutex
-	pendingPayByKey    map[string]pendingInferenceResult
-	peerLogMu          sync.Mutex
-	peerLogged         map[string]struct{}
-	peerConnMu         sync.Mutex
-	peerConnCount      map[peer.ID]int
-	peerLastGone       map[peer.ID]time.Time
-	peerDisconTmr      map[peer.ID]*time.Timer
-	bootstrapPeerIDs   map[peer.ID]struct{}
+	host                host.Host
+	dht                 *dht.IpfsDHT
+	bootstraps          []peer.AddrInfo
+	startedAt           time.Time
+	metricsSrv          *http.Server
+	allowedGatewayPeers map[peer.ID]struct{}
+	paymentDebtMu       sync.Mutex
+	paymentDebtByPayer  map[string]int64
+	peerLogMu           sync.Mutex
+	peerLogged          map[string]struct{}
+	peerConnMu          sync.Mutex
+	peerConnCount       map[peer.ID]int
+	peerLastGone        map[peer.ID]time.Time
+	peerDisconTmr       map[peer.ID]*time.Timer
+	bootstrapPeerIDs    map[peer.ID]struct{}
 
 	inflightInference atomic.Int64
 	statsMu           sync.RWMutex
@@ -207,17 +205,17 @@ func startBase(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 	}
 
 	r := &Runtime{
-		host:               h,
-		dht:                kdht,
-		bootstraps:         bootstraps,
-		startedAt:          time.Now(),
-		paymentDebtByPayer: make(map[string]int64),
-		pendingPayByKey:    make(map[string]pendingInferenceResult),
-		peerLogged:         make(map[string]struct{}),
-		peerConnCount:      make(map[peer.ID]int),
-		peerLastGone:       make(map[peer.ID]time.Time),
-		peerDisconTmr:      make(map[peer.ID]*time.Timer),
-		bootstrapPeerIDs:   make(map[peer.ID]struct{}),
+		host:                h,
+		dht:                 kdht,
+		bootstraps:          bootstraps,
+		startedAt:           time.Now(),
+		allowedGatewayPeers: make(map[peer.ID]struct{}),
+		paymentDebtByPayer:  make(map[string]int64),
+		peerLogged:          make(map[string]struct{}),
+		peerConnCount:       make(map[peer.ID]int),
+		peerLastGone:        make(map[peer.ID]time.Time),
+		peerDisconTmr:       make(map[peer.ID]*time.Timer),
+		bootstrapPeerIDs:    make(map[peer.ID]struct{}),
 	}
 	for _, b := range bootstraps {
 		if b.ID != "" {
@@ -235,7 +233,22 @@ func Start(ctx context.Context, cfg *config.Config) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.inferencePaywall = buildInferencePaywallConfig(cfg)
+	for _, ps := range cfg.Node.AllowedGatewayPeers {
+		ps = strings.TrimSpace(ps)
+		if ps == "" {
+			continue
+		}
+		pid, err := peer.Decode(ps)
+		if err != nil {
+			_ = r.dht.Close()
+			_ = r.host.Close()
+			return nil, fmt.Errorf("node.allowed_gateway_peers: invalid peer id %q: %w", ps, err)
+		}
+		r.allowedGatewayPeers[pid] = struct{}{}
+	}
+	if len(r.allowedGatewayPeers) > 0 {
+		log.Printf("inference access: allowlist active (%d official gateway peer id(s))", len(r.allowedGatewayPeers))
+	}
 	r.logDialAddrs()
 
 	go r.bootstrapReconnectLoop(ctx)
@@ -413,4 +426,15 @@ func (r *Runtime) PingPeer(ctx context.Context, target peer.ID) (time.Duration, 
 	case <-ctx.Done():
 		return 0, ctx.Err()
 	}
+}
+
+func (r *Runtime) isAllowedInferencePeer(id peer.ID) bool {
+	if r == nil || id == "" {
+		return false
+	}
+	if len(r.allowedGatewayPeers) == 0 {
+		return true
+	}
+	_, ok := r.allowedGatewayPeers[id]
+	return ok
 }

--- a/pkg/node/x402_paywall.go
+++ b/pkg/node/x402_paywall.go
@@ -1,15 +1,9 @@
 package node
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/mrostamii/tooti/pkg/apiv1"
 	"github.com/mrostamii/tooti/pkg/config"
@@ -17,9 +11,7 @@ import (
 )
 
 const (
-	inferenceParamPaymentSignature = "payment_signature"
-	inferenceParamResourceURL      = "x402_resource_url"
-	inferenceParamMaxTokens        = "max_tokens"
+	inferenceParamMaxTokens = "max_tokens"
 )
 
 type x402InferencePaywallConfig struct {
@@ -41,16 +33,6 @@ type inferencePaymentSession struct {
 	PriorDebtAtomic int64
 	PrepaidAtomic   int64
 	Pricing         x402PricingConfig
-	PaymentKey      string
-	ResourceURL     string
-	Requirement     x402spike.PaymentRequirements
-	PendingResult   *pendingInferenceResult
-}
-
-type pendingInferenceResult struct {
-	Content    string
-	TokensUsed int64
-	LatencyMs  int64
 }
 
 type x402RemoteErrorEnvelope struct {
@@ -71,33 +53,6 @@ func (e *PaymentRequiredError) Error() string {
 		return "payment required"
 	}
 	return e.Message
-}
-
-func buildInferencePaywallConfig(cfg *config.Config) *x402InferencePaywallConfig {
-	if cfg == nil || !cfg.Node.X402.Enabled {
-		return nil
-	}
-	return &x402InferencePaywallConfig{
-		FacilitatorURL: strings.TrimSpace(cfg.Node.X402.FacilitatorURL),
-		Requirement: x402spike.PaymentRequirements{
-			Scheme:            "exact",
-			Network:           strings.TrimSpace(cfg.Node.X402.Network),
-			Amount:            "1",
-			Asset:             strings.TrimSpace(cfg.Node.X402.Asset),
-			PayTo:             strings.TrimSpace(cfg.Node.X402.PayTo),
-			MaxTimeoutSeconds: 60,
-			Extra: map[string]any{
-				"name":    strings.TrimSpace(cfg.Node.X402.TokenName),
-				"version": strings.TrimSpace(cfg.Node.X402.TokenVersion),
-			},
-		},
-		Pricing: x402PricingConfig{
-			AtomicPer1KTokens:   cfg.Node.X402.PricePer1KAtomic,
-			MinAmountAtomic:     cfg.Node.X402.MinAmountAtomic,
-			DefaultOutputTokens: cfg.Node.X402.DefaultOutputTokens,
-		},
-		ModelPricing: cfg.Models.ModelPricing,
-	}
 }
 
 func buildAdvertisedModelPricing(cfg *config.Config) map[string]ModelPricingHint {
@@ -135,114 +90,6 @@ func buildAdvertisedModelPricing(cfg *config.Config) map[string]ModelPricingHint
 		return nil
 	}
 	return out
-}
-
-func (r *Runtime) enforceInferencePayment(req *apiv1.InferenceRequest) (*inferencePaymentSession, string, bool) {
-	if r == nil || r.inferencePaywall == nil {
-		return nil, "", true
-	}
-	paywall := r.inferencePaywall
-	resourceURL := "http://tooti.local/v1/chat/completions"
-	if req != nil && req.GetParams() != nil {
-		if got := strings.TrimSpace(req.GetParams()[inferenceParamResourceURL]); got != "" {
-			resourceURL = got
-		}
-	}
-	requirement, quotedAmount := computeInferenceRequirementAndAmount(paywall, req)
-	paymentRequired := x402spike.PaymentRequired{
-		X402Version: 2,
-		Error:       "PAYMENT-SIGNATURE header is required",
-		Resource: x402spike.ResourceInfo{
-			URL:         resourceURL,
-			Description: "paid inference request",
-			MimeType:    "application/json",
-		},
-		Accepts:    []x402spike.PaymentRequirements{requirement},
-		Extensions: map[string]any{},
-	}
-
-	paymentHeader := ""
-	if req != nil && req.GetParams() != nil {
-		paymentHeader = strings.TrimSpace(req.GetParams()[inferenceParamPaymentSignature])
-	}
-	if paymentHeader == "" {
-		return nil, encodePaymentRequiredEnvelope("PAYMENT-SIGNATURE header is required", paymentRequired, x402spike.SettlementResponse{}), false
-	}
-
-	var payload x402spike.PaymentPayload
-	if err := x402spike.DecodeBase64JSON(paymentHeader, &payload); err != nil {
-		paymentRequired.Error = "invalid PAYMENT-SIGNATURE header"
-		return nil, encodePaymentRequiredEnvelope(paymentRequired.Error, paymentRequired, x402spike.SettlementResponse{}), false
-	}
-	payer := strings.ToLower(strings.TrimSpace(payload.Payload.Authorization.From))
-	paymentKey := makePaymentKey(req, payer)
-	pending, hasPending := r.getPendingInferenceResult(paymentKey)
-	priorDebt := r.getPaymentDebt(payer)
-	requirementWithDebt := requirement
-	if priorDebt > 0 {
-		requiredAtomic := priorDebt
-		if !hasPending {
-			requiredAtomic += quotedAmount
-		}
-		if requiredAtomic < 1 {
-			requiredAtomic = 1
-		}
-		requirementWithDebt.Amount = strconv.FormatInt(requiredAtomic, 10)
-		paymentRequired.Accepts = []x402spike.PaymentRequirements{requirementWithDebt}
-	}
-	if err := validateAcceptedPayment(payload.Accepted, requirementWithDebt); err != nil {
-		paymentRequired.Error = err.Error()
-		return nil, encodePaymentRequiredEnvelope(paymentRequired.Error, paymentRequired, x402spike.SettlementResponse{}), false
-	}
-	prepaidAtomic, err := strconv.ParseInt(strings.TrimSpace(payload.Accepted.Amount), 10, 64)
-	if err != nil || prepaidAtomic <= 0 {
-		paymentRequired.Error = "invalid PAYMENT-SIGNATURE amount"
-		return nil, encodePaymentRequiredEnvelope(paymentRequired.Error, paymentRequired, x402spike.SettlementResponse{}), false
-	}
-
-	if strings.TrimSpace(paywall.FacilitatorURL) == "" {
-		if hasPending && priorDebt > 0 {
-			r.setPaymentDebt(payer, 0)
-		}
-		return &inferencePaymentSession{
-			Payer:           payer,
-			Model:           strings.TrimSpace(req.GetModel()),
-			PriorDebtAtomic: priorDebt,
-			PrepaidAtomic:   prepaidAtomic,
-			Pricing:         resolveInferencePricing(paywall, req),
-			PaymentKey:      paymentKey,
-			ResourceURL:     resourceURL,
-			Requirement:     requirementWithDebt,
-			PendingResult:   pendingOrNil(pending, hasPending),
-		}, "", true
-	}
-	settle, _, _, err := settleWithFacilitator(paywall.FacilitatorURL, payload, requirementWithDebt)
-	if err != nil {
-		paymentRequired.Error = "facilitator error: " + err.Error()
-		return nil, encodePaymentRequiredEnvelope(paymentRequired.Error, paymentRequired, x402spike.SettlementResponse{}), false
-	}
-	if !settle.Success {
-		if strings.TrimSpace(settle.ErrorReason) != "" {
-			paymentRequired.Error = "payment settlement failed: " + strings.TrimSpace(settle.ErrorReason)
-		} else {
-			paymentRequired.Error = "payment settlement failed"
-		}
-		return nil, encodePaymentRequiredEnvelope(paymentRequired.Error, paymentRequired, settle), false
-	}
-	if hasPending && priorDebt > 0 {
-		r.setPaymentDebt(payer, 0)
-	}
-	return &inferencePaymentSession{
-		Payer:           payer,
-		Model:           strings.TrimSpace(req.GetModel()),
-		PriorDebtAtomic: priorDebt,
-		PrepaidAtomic:   prepaidAtomic,
-		Pricing:         resolveInferencePricing(paywall, req),
-		PaymentKey:      paymentKey,
-		ResourceURL:     resourceURL,
-		Requirement:     requirementWithDebt,
-		PendingResult:   pendingOrNil(pending, hasPending),
-	}, "", true
 }
 
 func computeInferenceRequirement(paywall *x402InferencePaywallConfig, req *apiv1.InferenceRequest) x402spike.PaymentRequirements {
@@ -364,93 +211,6 @@ func decodePaymentRequiredEnvelope(msg string) (*PaymentRequiredError, bool) {
 	}, true
 }
 
-func settleWithFacilitator(
-	facilitatorURL string,
-	payload x402spike.PaymentPayload,
-	req x402spike.PaymentRequirements,
-) (x402spike.SettlementResponse, int64, int64, error) {
-	facilitatorURL = strings.TrimRight(strings.TrimSpace(facilitatorURL), "/")
-	requestBody := x402VerifyRequest{
-		X402Version:         2,
-		PaymentPayload:      payload,
-		PaymentRequirements: req,
-	}
-	verifyStarted := time.Now()
-	var verifyRes x402VerifyResponse
-	if err := postJSON(facilitatorURL+"/verify", requestBody, &verifyRes); err != nil {
-		return x402spike.SettlementResponse{}, time.Since(verifyStarted).Milliseconds(), 0, err
-	}
-	verifyMS := time.Since(verifyStarted).Milliseconds()
-	if !verifyRes.IsValid {
-		return x402spike.SettlementResponse{
-			Success:     false,
-			ErrorReason: verifyRes.InvalidReason,
-			Payer:       verifyRes.Payer,
-			Transaction: "",
-			Network:     req.Network,
-		}, verifyMS, 0, nil
-	}
-	settleStarted := time.Now()
-	var settleRes x402spike.SettlementResponse
-	if err := postJSON(facilitatorURL+"/settle", requestBody, &settleRes); err != nil {
-		return x402spike.SettlementResponse{}, verifyMS, time.Since(settleStarted).Milliseconds(), err
-	}
-	return settleRes, verifyMS, time.Since(settleStarted).Milliseconds(), nil
-}
-
-type x402VerifyRequest struct {
-	X402Version         int                           `json:"x402Version"`
-	PaymentPayload      x402spike.PaymentPayload      `json:"paymentPayload"`
-	PaymentRequirements x402spike.PaymentRequirements `json:"paymentRequirements"`
-}
-
-type x402VerifyResponse struct {
-	IsValid       bool   `json:"isValid"`
-	InvalidReason string `json:"invalidReason,omitempty"`
-	Payer         string `json:"payer,omitempty"`
-}
-
-func postJSON(url string, reqBody any, out any) error {
-	raw, err := json.Marshal(reqBody)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("POST %s returned status %d", url, resp.StatusCode)
-	}
-	return json.NewDecoder(resp.Body).Decode(out)
-}
-
-func validateAcceptedPayment(got, want x402spike.PaymentRequirements) error {
-	if got.Scheme != want.Scheme ||
-		got.Network != want.Network ||
-		got.Amount != want.Amount ||
-		got.Asset != want.Asset ||
-		got.PayTo != want.PayTo {
-		return fmt.Errorf("PAYMENT-SIGNATURE accepted requirement mismatch")
-	}
-	return nil
-}
-
-func pendingOrNil(v pendingInferenceResult, ok bool) *pendingInferenceResult {
-	if !ok {
-		return nil
-	}
-	cp := v
-	return &cp
-}
-
 func (r *Runtime) getPaymentDebt(payer string) int64 {
 	payer = strings.ToLower(strings.TrimSpace(payer))
 	if r == nil || payer == "" {
@@ -476,72 +236,6 @@ func (r *Runtime) setPaymentDebt(payer string, debt int64) {
 		return
 	}
 	r.paymentDebtByPayer[payer] = debt
-}
-
-func (r *Runtime) setPendingInferenceResult(key string, result pendingInferenceResult) {
-	key = strings.TrimSpace(key)
-	if r == nil || key == "" {
-		return
-	}
-	r.pendingPayMu.Lock()
-	defer r.pendingPayMu.Unlock()
-	r.pendingPayByKey[key] = result
-}
-
-func (r *Runtime) getPendingInferenceResult(key string) (pendingInferenceResult, bool) {
-	key = strings.TrimSpace(key)
-	if r == nil || key == "" {
-		return pendingInferenceResult{}, false
-	}
-	r.pendingPayMu.Lock()
-	defer r.pendingPayMu.Unlock()
-	v, ok := r.pendingPayByKey[key]
-	return v, ok
-}
-
-func (r *Runtime) deletePendingInferenceResult(key string) {
-	key = strings.TrimSpace(key)
-	if r == nil || key == "" {
-		return
-	}
-	r.pendingPayMu.Lock()
-	defer r.pendingPayMu.Unlock()
-	delete(r.pendingPayByKey, key)
-}
-
-func makePaymentKey(req *apiv1.InferenceRequest, payer string) string {
-	type keyMsg struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
-	}
-	type keyReq struct {
-		Payer    string            `json:"payer"`
-		Model    string            `json:"model"`
-		Messages []keyMsg          `json:"messages"`
-		Params   map[string]string `json:"params"`
-	}
-	out := keyReq{
-		Payer:  strings.ToLower(strings.TrimSpace(payer)),
-		Params: map[string]string{},
-	}
-	if req != nil {
-		out.Model = strings.TrimSpace(req.GetModel())
-		for _, m := range req.GetMessages() {
-			out.Messages = append(out.Messages, keyMsg{
-				Role:    m.GetRole(),
-				Content: m.GetContent(),
-			})
-		}
-		for k, v := range req.GetParams() {
-			if strings.EqualFold(strings.TrimSpace(k), inferenceParamPaymentSignature) {
-				continue
-			}
-			out.Params[k] = v
-		}
-	}
-	raw, _ := json.Marshal(out)
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:])
 }
 
 func (r *Runtime) reconcileActualUsage(session *inferencePaymentSession, tokensUsed int64) {
@@ -586,23 +280,4 @@ func (r *Runtime) computeActualDueAtomic(session *inferencePaymentSession, token
 		actualDue = 1
 	}
 	return actualDue
-}
-
-func (r *Runtime) markAbortedStreamDebt(session *inferencePaymentSession) {
-	if r == nil || session == nil || session.Payer == "" {
-		return
-	}
-	penalty := session.Pricing.MinAmountAtomic
-	if penalty < 1 {
-		penalty = 1
-	}
-	current := r.getPaymentDebt(session.Payer)
-	r.setPaymentDebt(session.Payer, current+penalty)
-	logInferenceEvent(map[string]any{
-		"event":           "x402_stream_aborted_debt",
-		"payer":           session.Payer,
-		"model":           session.Model,
-		"penalty_atomic":  penalty,
-		"new_debt_atomic": current + penalty,
-	})
 }


### PR DESCRIPTION
## Summary

Completes **prepaid-only inference** for official gateways: chat is billed with **prepaid API keys** (reserve/finalize); **x402** is limited to **prepaid top-up**. Adds **node gateway peer allowlists**, removes the **HMAC relay** path, and improves **`tooti pay chat`** for prepaid Bearer auth.

## Gateway

- Official **`POST /v1/chat/completions`** uses **prepaid API keys** + DB reserve/finalize; no per-request x402 on chat for that path; **`PAYMENT-SIGNATURE`** is not forwarded to provider nodes for official prepaid routing.
- **`POST /v1/prepaid/topup`** remains the **x402** entrypoint for crediting balance.

## Node

- Inference handlers no longer enforce the old **x402 / prepaid relay HMAC** payment path on libp2p.
- New config: **`node.allowed_gateway_peers`** — when set, only those libp2p peers may run inference; empty allowlist keeps prior “open” behavior for local/homelab.
- Disallowed peers get a clear **`unauthorized inference peer`** response (not a 402 payment challenge).

## CLI

- **`tooti pay chat`** accepts **`-api-key`** (Bearer for prepaid) and can load a key from **`~/.tooti/pay-state.json`** using the **`-url`** host (same profiles as **`pay topup`**).

## Cleanup

- Removed **`pkg/prepaidrelay`** and related config/command wiring.
- **`node.example.yaml`** updated (allowlist; HMAC docs removed).

## Testing

- `go test ./...`